### PR TITLE
Add types to package.json exports

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -50,6 +50,7 @@
     "exports": {
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/types/index.d.ts"
     }
 }

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -36,7 +36,8 @@
   "exports": {
     "import": "./dist/esm/index.js",
     "require": "./dist/cjs/index.js",
-    "default": "./dist/cjs/index.js"
+    "default": "./dist/cjs/index.js",
+    "types": "./dist/types/index.d.ts"
   },
   "dependencies": {
     "@axiomhq/js": "workspace:*",

--- a/packages/winston/package.json
+++ b/packages/winston/package.json
@@ -40,6 +40,7 @@
     "exports": {
         "import": "./dist/esm/index.js",
         "require": "./dist/cjs/index.js",
-        "default": "./dist/cjs/index.js"
+        "default": "./dist/cjs/index.js",
+        "types": "./dist/types/index.d.ts"
     }
 }


### PR DESCRIPTION
Otherwise projects might complain, here's Vue:

```
src/App.vue:5:23 - error TS7016: Could not find a declaration file for module '@axiomhq/js'. '/Users/arne/[...]/node_modules/@axiomhq/js/dist/esm/index.js' implicitly has an 'any' type.
  There are types at '/Users/arne/[...]/node_modules/@axiomhq/js/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@axiomhq/js' library may need to update its package.json or typings.
````

See also https://github.com/microsoft/TypeScript/issues/46334

Closes #28 