### PR TITLE
Release 0.1.2 (all packages)

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2023-06-26
+
+### Fixed
+
+- Add types to package.json exports ([#29](https://github.com/axiomhq/axiom-js/pull/29))
+- Fix wrong reference for flush example ([#27](https://github.com/axiomhq/axiom-js/pull/27))
+- Fake process.env for browsers ([#26](https://github.com/axiomhq/axiom-js/pull/26))
+
+## [0.1.1] - 2023-06-20
+
+### Added
+
+- Export ClientOptions in client ([#17](https://github.com/axiomhq/axiom-js/pull/17))
+
+### Fixed
+
+- Add flush comment to README.md ([#9)](https://github.com/axiomhq/axiom-js/pull/9))
+
+### Changed
+
+- Rename Client => Axiom ([#17](https://github.com/axiomhq/axiom-js/pull/17))
+
+## [0.1.0] - 2023-06-14
+
+Initial release
+
+[unreleased]: https://github.com/axiomhq/axiom-js/compare/js-0.1.2...HEAD
+[0.1.2]: https://github.com/axiomhq/axiom-js/releases/tag/js-0.1.2
+[0.1.1]: https://github.com/axiomhq/axiom-js/releases/tag/js-0.1.1
+[0.1.0]: https://github.com/axiomhq/axiom-js/releases/tag/js-0.1.0

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/js",
     "description": "The official javascript bindings for the Axiom API",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "author": "Axiom, Inc.",
     "license": "MIT",
     "contributors": [

--- a/packages/pino/CHANGELOG.md
+++ b/packages/pino/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2023-06-26
+
+### Fixed
+
+- Add types to package.json exports ([#29](https://github.com/axiomhq/axiom-js/pull/29))
+- Fake process.env for browsers ([#26](https://github.com/axiomhq/axiom-js/pull/26))
+
+## [0.1.1] - 2023-06-20
+
+### Fixed
+
+- Fix dependency on unreleased version of `@axiomhq/js`
+
+## [0.1.0] - 2023-06-19
+
+Initial release
+
+[unreleased]: https://github.com/axiomhq/axiom-js/compare/pino-0.1.2...HEAD
+[0.1.2]: https://github.com/axiomhq/axiom-js/releases/tag/pino-0.1.2
+[0.1.1]: https://github.com/axiomhq/axiom-js/releases/tag/pino-0.1.1
+[0.1.0]: https://github.com/axiomhq/axiom-js/releases/tag/pino-0.1.0

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/pino",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "The official Axiom transport for Pino",
   "main": "dist/cjs/index.ts",
   "types": "dist/types/index.d.ts",

--- a/packages/winston/CHANGELOG.md
+++ b/packages/winston/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.2] - 2023-06-26
+
+### Fixed
+
+- Add types to package.json exports ([#29](https://github.com/axiomhq/axiom-js/pull/29))
+- Fake process.env for browsers ([#26](https://github.com/axiomhq/axiom-js/pull/26))
+
+## [0.1.1] - 2023-06-20
+
+### Fixed
+
+- Updated @axiomhq/js dependency
+
+## [0.1.0] - 2023-06-14
+
+Initial release
+
+[unreleased]: https://github.com/axiomhq/axiom-js/compare/winston-0.1.2...HEAD
+[0.1.2]: https://github.com/axiomhq/axiom-js/releases/tag/winston-0.1.2
+[0.1.1]: https://github.com/axiomhq/axiom-js/releases/tag/winston-0.1.1
+[0.1.0]: https://github.com/axiomhq/axiom-js/releases/tag/winston-0.1.0

--- a/packages/winston/package.json
+++ b/packages/winston/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/winston",
     "description": "The official Axiom transport for winston logger",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "main": "dist/cjs/index.js",
     "types": "dist/types/index.d.ts",
     "module": "dist/esm/index.js",


### PR DESCRIPTION
This PR also adds CHANGELOG.md files based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).

- [`@axiomhq/js` CHANGELOG.md](https://github.com/axiomhq/axiom-js/blob/arne/release-012/packages/js/CHANGELOG.md)
- [`@axiomhq/pino` CHANGELOG.md](https://github.com/axiomhq/axiom-js/blob/arne/release-012/packages/pino/CHANGELOG.md)
- [`@axiomhq/winston` CHANGELOG.md](https://github.com/axiomhq/axiom-js/blob/arne/release-012/packages/winston/CHANGELOG.md)

We now tag releases of packages with `<package>-<tag>`, e.g. `pino-0.1.2`.