### PR TITLE
Option to flatten ingestion data 

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -45,6 +45,7 @@
     "dependencies": {
         "cross-fetch": "^3.1.5",
         "fetch-retry": "^5.0.3",
+        "flatted": "^3.2.7",
         "uuid": "^8.3.2"
     },
     "exports": {

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -233,6 +233,10 @@ export interface IngestOptions {
    * delimiter used in the csv file
    */
   csvDelimiter?: string;
+  /**
+   * flatten json, preventing circular dependencies
+   */
+  flattenData?: boolean;
 }
 
 /**

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -2,6 +2,7 @@ import { datasets } from './datasets';
 import { users } from './users';
 import { Batch, createBatchKey } from './batch';
 import HTTPClient, { ClientOptions } from './httpClient';
+import { stringify as flattedStringify} from 'flatted';
 
 class BaseClient extends HTTPClient {
   datasets: datasets.Service;
@@ -145,7 +146,11 @@ export class AxiomWithoutBatching extends BaseClient {
    */
   ingest(dataset: string, events: Array<object> | object, options?: IngestOptions): Promise<IngestStatus> {
     const array = Array.isArray(events) ? events : [events];
-    const json = array.map((v) => JSON.stringify(v)).join('\n');
+    const json = array
+      .map((v) => {
+        options?.flattenData ? flattedStringify(v) : JSON.stringify(v);
+      })
+      .join('\n');
     return this.ingestRaw(dataset, json, ContentType.NDJSON, ContentEncoding.Identity, options);
   }
 }

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -148,7 +148,7 @@ export class AxiomWithoutBatching extends BaseClient {
     const array = Array.isArray(events) ? events : [events];
     const json = array
       .map((v) => {
-        options?.flattenData ? flattedStringify(v) : JSON.stringify(v);
+        return options?.flattenData ? flattedStringify(v) : JSON.stringify(v);
       })
       .join('\n');
     return this.ingestRaw(dataset, json, ContentType.NDJSON, ContentEncoding.Identity, options);

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -194,17 +194,17 @@ describe('Axiom', () => {
     expect(response).not.toEqual('undefined');
     expect(response.matches).toHaveLength(2);
   });
-  it('should successfully handle circular JSON during ingestion with correct option', async () => {
-    const obj: any = { prop1: 'Test', prop2: null };
-    obj.prop2 = obj;
+  it('should successfully handle circular JSON during ingestion with correct options', async () => {
+    const circularReferenceObject: any = { foo: 'bar', circularAttribute: null };
+    circularReferenceObject.circularAttribute = circularReferenceObject;
 
     expect(() => {
-      axiom.ingest('test', [obj]);
+      axiom.ingest('test', [circularReferenceObject]);
     }).toThrow(TypeError);
 
     const options: IngestOptions = { flattenData: true };
     expect(() => {
-      axiom.ingest('test', [obj], options);
+      axiom.ingest('test', [circularReferenceObject], options);
     }).not.toThrow(TypeError);
   });
 });

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, beforeEach } from '@jest/globals';
 
-import { ContentType, ContentEncoding, AxiomWithoutBatching } from '../../src/client';
+import { ContentType, ContentEncoding, AxiomWithoutBatching, IngestOptions } from '../../src/client';
 import { AxiomTooManyRequestsError } from '../../src/fetchClient';
 import { headerAPILimit, headerAPIRateRemaining, headerAPIRateReset, headerRateScope } from '../../src/limit';
 import { mockFetchResponse, testMockedFetchCall } from '../lib/mock';
@@ -193,5 +193,18 @@ describe('Axiom', () => {
     response = await axiom.query("['test'] | where response == 304", options);
     expect(response).not.toEqual('undefined');
     expect(response.matches).toHaveLength(2);
+  });
+  it('should successfully handle circular JSON during ingestion with correct option', async () => {
+    const obj: any = { prop1: 'Test', prop2: null };
+    obj.prop2 = obj;
+
+    expect(() => {
+      axiom.ingest('test', [obj]);
+    }).toThrow(TypeError);
+
+    const options: IngestOptions = { flattenData: true };
+    expect(() => {
+      axiom.ingest('test', [obj], options);
+    }).not.toThrow(TypeError);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -144,6 +144,9 @@ importers:
       fetch-retry:
         specifier: ^5.0.3
         version: 5.0.6
+      flatted:
+        specifier: ^3.2.7
+        version: 3.2.7
       uuid:
         specifier: ^8.3.2
         version: 8.3.2


### PR DESCRIPTION
Option fixing a minor issue I came across and reported as #46 

The main goal is allowing users to flatten data for logging if needed, mostly for preventing circular references in objects resulting in a Type Error when trying to JSON.stringify such data. Examples of naturally circular structures are Node's request object or some exception objects.

I've added it as an Ingestion option rather than resolving to it by default. The main reasons for that are that in many cases I would prefer to get an exception when trying to log circular data and figuring out why that's happening, the second one possibly being performance. I couldn't find any serious enough resources comparing the performance of default JSON.stringify and flatted stringify, although I reckon there shouldn't be much difference.

I decided to use a package for the flattening rather than trying to achieve it myself, even though it seems doable in just a few lines of code. I reckon that the added dependency and the tiny increase in size (0.5K) are worth it.