### PR TITLE
Fix return type of list datasets

### DIFF
--- a/packages/js/src/datasets.ts
+++ b/packages/js/src/datasets.ts
@@ -37,7 +37,7 @@ export namespace datasets {
   export class Service extends HTTPClient {
     private readonly localPath = '/v1/datasets';
 
-    list = (): Promise<[Dataset]> => this.client.get(this.localPath);
+    list = (): Promise<Dataset[]> => this.client.get(this.localPath);
 
     get = (id: string): Promise<Dataset> => this.client.get(this.localPath + '/' + id);
 


### PR DESCRIPTION
In Typescript, arrays are typed as `T[]` (or `Array<T>`), `[T]` means a tuple where the first element is type `T`. The example didn't catch this as at runtime they are represented as arrays (and therefore iterable the same way), however assignments are typechecked so the array length and element types are restricted to what is defined in the tuple.