### PR TITLE
fix: provide onError to catch errors on fetch promises

### DIFF
--- a/e2e/nextjs-app/test/ingest.spec.ts
+++ b/e2e/nextjs-app/test/ingest.spec.ts
@@ -59,21 +59,4 @@ describe('Ingestion & query on different runtime', () => {
     expect(qResp.matches![0].data.foo).toEqual('bar');
     expect(qResp.matches![1].data.bar).toEqual('baz');
   });
-
-  // TODO: enable this test again when env vars are available on browser runtime
-  // it('ingest on a browser runtime should succeed', async () => {
-  //   const startTime = new Date(Date.now()).toISOString();
-  //   // call route that ingests logs
-  //   const resp = await fetch(process.env.TESTING_TARGET_URL + '/ingest');
-  //   expect(resp.status).toEqual(200);
-
-  //   // check dataset for ingested logs
-  //   const qResp = await axiom.query(`['${datasetName}'] | where ['test'] == "ingest_on_browser"`, {
-  //     startTime,
-  //   });
-  //   expect(qResp.matches).toBeDefined();
-  //   expect(qResp.matches).toHaveLength(2);
-  //   expect(qResp.matches![0].data.foo).toEqual('bar');
-  //   expect(qResp.matches![1].data.bar).toEqual('baz');
-  // });
 });

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -51,7 +51,8 @@ let client = new Axiom({
   token: '',
   ...,
   onError: (err) => {
-    console.log('ERROR:', err);
+    console.error('ERROR:', err);
   }
 });
 ```
+by default `onError` is set to `console.error`.

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -40,3 +40,18 @@ console.log(res);
 ```
 
 For further examples, head over to the [examples](../../examples/js) directory.
+
+
+## Capture Errors
+
+To capture errors, you can pass a method `onError` to the client:
+
+```ts
+let client = new Axiom({
+  token: '',
+  ...,
+  onError: (err) => {
+    console.log('ERROR:', err);
+  }
+});
+```

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/js",
     "description": "The official javascript bindings for the Axiom API",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "author": "Axiom, Inc.",
     "license": "MIT",
     "contributors": [

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -43,8 +43,7 @@ class BaseClient extends HTTPClient {
     contentEncoding: ContentEncoding = ContentEncoding.Identity,
     options?: IngestOptions,
   ): Promise<IngestStatus> => {
-    try {
-      return this.client.post(
+      return this.client.post<IngestStatus>(
         this.localPath + '/datasets/' + dataset + '/ingest',
         {
           headers: {
@@ -58,17 +57,17 @@ class BaseClient extends HTTPClient {
           'timestamp-format': options?.timestampFormat as string,
           'csv-delimiter': options?.csvDelimiter as string,
         },
-      );
-    } catch (err: any) {
-      this.onError(err);
-      return Promise.resolve({
-        ingested: 0,
-        failed: 0,
-        processedBytes: 0,
-        blocksCreated: 0,
-        walLength: 0,
+      ).catch((err) => {
+        this.onError(err);
+        return Promise.resolve({
+          ingested: 0,
+          failed: 0,
+          processedBytes: 0,
+          blocksCreated: 0,
+          walLength: 0,
+        });
       });
-    }}
+    }
 
   queryLegacy = (dataset: string, query: QueryLegacy, options?: QueryOptions): Promise<QueryLegacyResult> =>
     this.client.post(

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -7,11 +7,15 @@ class BaseClient extends HTTPClient {
   datasets: datasets.Service;
   users: users.Service;
   localPath = '/v1';
+  onError = (err: Error) => console.error(err);
 
   constructor(options: ClientOptions) {
     super(options);
     this.datasets = new datasets.Service(options);
     this.users = new users.Service(options);
+    if (options.onError) {
+      this.onError = options.onError;
+    }
   }
 
   /**
@@ -199,9 +203,9 @@ export class Axiom extends BaseClient {
   flush = async (): Promise<void> => {
     let promises: Array<Promise<IngestStatus | void>> = [];
     for (const key in this.batch) {
-      promises.push(this.batch[key].flush());
+      promises.push(this.batch[key].flush().catch(this.onError));
     }
-    await Promise.all(promises);
+    await Promise.all(promises).catch(this.onError);
   };
 }
 

--- a/packages/js/src/httpClient.ts
+++ b/packages/js/src/httpClient.ts
@@ -31,6 +31,7 @@ export interface ClientOptions {
    * need to change this unless you are using a self-hosted version of Axiom.
    */
   url?: string;
+  onError?: (error: Error) => void;
 }
 
 export default abstract class HTTPClient {

--- a/packages/js/test/lib/mock.ts
+++ b/packages/js/test/lib/mock.ts
@@ -9,6 +9,15 @@ export const mockFetchResponse = (body: any, statusCode: number = 200, headers =
   vi.spyOn(global, 'fetch').mockImplementationOnce(func);
 };
 
+export const mockFetchResponseErr = (headers = {}) => {
+  const resp = new Response(null, { status: 500, headers });
+  const func: () => Promise<Response> = () => {
+    return Promise.reject(resp);
+  };
+
+  vi.spyOn(global, 'fetch').mockImplementationOnce(func);
+};
+
 export const testMockedFetchCall = (test: any, body: any, statusCode: number = 200, headers = {}) => {
   const func: typeof fetch = (url: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
     test(url, init);

--- a/packages/js/test/lib/mock.ts
+++ b/packages/js/test/lib/mock.ts
@@ -9,8 +9,8 @@ export const mockFetchResponse = (body: any, statusCode: number = 200, headers =
   vi.spyOn(global, 'fetch').mockImplementationOnce(func);
 };
 
-export const mockFetchResponseErr = (headers = {}) => {
-  const resp = new Response(null, { status: 500, headers });
+export const mockFetchResponseErr = (statusCode = 500, headers = {}) => {
+  const resp = new Response(null, { status: statusCode, headers });
   const func: () => Promise<Response> = () => {
     return Promise.reject(resp);
   };

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it, beforeEach } from 'vitest';
 import { ContentType, ContentEncoding, Axiom, AxiomWithoutBatching } from '../../src/client';
 import { AxiomTooManyRequestsError } from '../../src/fetchClient';
 import { headerAPILimit, headerAPIRateRemaining, headerAPIRateReset, headerRateScope } from '../../src/limit';
-import { mockFetchResponse, testMockedFetchCall } from '../lib/mock';
+import { mockFetchResponse, mockFetchResponseErr, testMockedFetchCall } from '../lib/mock';
 
 const queryLegacyResult = {
   status: {
@@ -201,11 +201,11 @@ describe('Axiom', () => {
       console.log('callback has been called', err);
       errorCaptured = true;
     } });
-    mockFetchResponse({}, 500);
+    mockFetchResponseErr();
 
     client.ingest('test', [{ name: 'test' }]);
     client.ingest('test', [{ name: 'test' }]);
     await client.flush();
     expect(true).toEqual(errorCaptured);
-  })
+  }, 50000)
 });

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, beforeEach } from 'vitest';
+import { describe, expect, it, beforeEach, vitest } from 'vitest';
 
 import { ContentType, ContentEncoding, Axiom, AxiomWithoutBatching } from '../../src/client';
 import { AxiomTooManyRequestsError } from '../../src/fetchClient';
@@ -82,8 +82,8 @@ describe('Axiom', () => {
 
   it('Retries failed 5xx requests', async () => {
     // TODO: this doesn't actually check that retries happened, fix
-    mockFetchResponse({}, 500);
-    mockFetchResponse({}, 500);
+    mockFetchResponse(null, 500);
+    mockFetchResponse(null, 500);
     mockFetchResponse([{ name: 'test' }], 200);
 
     const resp = await axiom.datasets.list();
@@ -91,121 +91,158 @@ describe('Axiom', () => {
     expect(resp.length).toEqual(1);
   });
 
-  it('Does not retry failed requests < 500', async () => {
-    // TODO: this doesn't actually check that retries happend or not, fix
-    mockFetchResponse({}, 401);
-    // global.fetch = mockFetchResponse([{ name: 'test' }], 200);
+  describe('Ingesting', () => {
 
-    expect(axiom.datasets.list).rejects.toThrow(new Error('Forbidden'));
+    it('Does not retry failed requests < 500', async () => {
+      // TODO: this doesn't actually check that retries happend or not, fix
+      mockFetchResponse({}, 401);
+      // global.fetch = mockFetchResponse([{ name: 'test' }], 200);
 
-    // create another request to ensure that
-    // the fetch mock was not consumed before
-    // const resp = await axiom.datasets.list();
-    // expect(fetch).toHaveBeenCalledTimes(2);
-    // expect(resp.length).toEqual(1);
+      await expect(axiom.datasets.list).rejects.toThrow(new Error('Forbidden'));
+
+      // create another request to ensure that
+      // the fetch mock was not consumed before
+      // const resp = await axiom.datasets.list();
+      // expect(fetch).toHaveBeenCalledTimes(2);
+      // expect(resp.length).toEqual(1);
+    });
+
+    it('No shortcircuit for ingest or query when there is api rate limit', async () => {
+      const resetTimeInSeconds = Math.floor(new Date().getTime() / 1000) + 1;
+      const headers: HeadersInit = {};
+      headers[headerRateScope] = 'anonymous';
+      headers[headerAPILimit] = '1000';
+      headers[headerAPIRateRemaining] = '0';
+      headers[headerAPIRateReset] = resetTimeInSeconds.toString();
+
+      mockFetchResponse({}, 429, headers);
+      expect(axiom.datasets.list).rejects.toBeInstanceOf(AxiomTooManyRequestsError);
+
+      // ingest and query should succeed
+      mockFetchResponse({}, 200, headers);
+      await axiom.ingest('test', [{ name: 'test' }]);
+
+      mockFetchResponse({}, 200, headers);
+      await axiom.query("['test']");
+    });
+
+    it('IngestString', async () => {
+      const query = [{ foo: 'bar' }, { foo: 'baz' }];
+
+      const ingestStatus = {
+        ingested: 2,
+        failed: 0,
+        failures: [],
+        processedBytes: 630,
+        blocksCreated: 0,
+        walLength: 2,
+      };
+      testMockedFetchCall((_: string, init: RequestInit) => {
+        expect(init.headers).toHaveProperty('Content-Type');
+        expect(init.body).toMatch(JSON.stringify(query));
+      }, ingestStatus);
+
+      const response = await axiom.ingestRaw('test', JSON.stringify(query), ContentType.JSON, ContentEncoding.Identity);
+      expect(response).toBeDefined();
+      expect(response.ingested).toEqual(2);
+      expect(response.failed).toEqual(0);
+    });
+
+    it('does not throw exception on ingest (50x failure)', async () => {
+      let client = new AxiomWithoutBatching({ url: clientURL, token: 'test' })
+      mockFetchResponseErr();
+
+      await expect(client.ingest('test', [{ name: 'test' }])).resolves.toBeTruthy();
+    }, 50000)
+
+    it('does not throw exception on ingest (40x failure)', async () => {
+      let client = new AxiomWithoutBatching({ url: clientURL, token: 'test' })
+      mockFetchResponseErr(401);
+
+      await expect(client.ingest('test', [{ name: 'test' }])).resolves.toBeTruthy();
+    }, 50000)
+
+    it('catch ingest errors', async () => {
+      let errorCaptured = false;
+      let client = new Axiom({
+        url: clientURL, token: 'test', onError: (err) => {
+          console.error('error callback has been called', err);
+          errorCaptured = true;
+        }
+      });
+      mockFetchResponseErr();
+
+      client.ingest('test', [{ name: 'test' }]);
+      await client.flush();
+      expect(errorCaptured).toEqual(true);
+    }, 50000)
+
+    it('catch ingest errors on WithoutBatching client', async () => {
+      let errorCaptured = false;
+      let client = new AxiomWithoutBatching({
+        url: clientURL, token: 'test', onError: (err) => {
+          console.error('error callback has been called', err);
+          errorCaptured = true;
+        }
+      });
+      mockFetchResponseErr();
+
+      await expect(client.ingest('test', [{ name: 'test' }])).resolves.toBeTruthy();
+
+      expect(true).toEqual(errorCaptured);
+    }, 50000)
+
+  })
+
+  describe('Querying', async () => {
+
+    it('Legacy Query', async () => {
+      mockFetchResponse(queryLegacyResult);
+
+      // works without options
+      let query = {
+        startTime: '2020-11-26T11:18:00Z',
+        endTime: '2020-11-17T11:18:00Z',
+        resolution: 'auto',
+      };
+      let response = await axiom.queryLegacy('test', query);
+      expect(response).toBeDefined();
+      expect(response.matches).toHaveLength(2);
+
+      // works with options
+      query = {
+        startTime: '2020-11-26T11:18:00Z',
+        endTime: '2020-11-17T11:18:00Z',
+        resolution: 'auto',
+      };
+      const options = {
+        streamingDuration: '1m',
+        noCache: true,
+      };
+
+      mockFetchResponse(queryLegacyResult);
+      response = await axiom.queryLegacy('test', query, options);
+      expect(response).toBeDefined();
+      expect(response.matches).toHaveLength(2);
+    });
+
+    it('APL Query', async () => {
+      mockFetchResponse(queryResult);
+      // works without options
+      let response = await axiom.query("['test'] | where response == 304");
+      expect(response).not.toEqual('undefined');
+      expect(response.matches).toHaveLength(2);
+
+      // works with options
+      const options = {
+        streamingDuration: '1m',
+        noCache: true,
+      };
+
+      mockFetchResponse(queryResult);
+      response = await axiom.query("['test'] | where response == 304", options);
+      expect(response).not.toEqual('undefined');
+      expect(response.matches).toHaveLength(2);
+    });
   });
-
-  it('No shortcircuit for ingest or query when there is api rate limit', async () => {
-    const resetTimeInSeconds = Math.floor(new Date().getTime() / 1000) + 1;
-    const headers: HeadersInit = {};
-    headers[headerRateScope] = 'anonymous';
-    headers[headerAPILimit] = '1000';
-    headers[headerAPIRateRemaining] = '0';
-    headers[headerAPIRateReset] = resetTimeInSeconds.toString();
-
-    mockFetchResponse({}, 429, headers);
-    expect(axiom.datasets.list).rejects.toBeInstanceOf(AxiomTooManyRequestsError);
-
-    // ingest and query should succeed
-    mockFetchResponse({}, 200, headers);
-    await axiom.ingest('test', [{ name: 'test' }]);
-
-    mockFetchResponse({}, 200, headers);
-    await axiom.query("['test']");
-  });
-
-  it('IngestString', async () => {
-    const query = [{ foo: 'bar' }, { foo: 'baz' }];
-
-    const ingestStatus = {
-      ingested: 2,
-      failed: 0,
-      failures: [],
-      processedBytes: 630,
-      blocksCreated: 0,
-      walLength: 2,
-    };
-    testMockedFetchCall((_: string, init: RequestInit) => {
-      expect(init.headers).toHaveProperty('Content-Type');
-      expect(init.body).toMatch(JSON.stringify(query));
-    }, ingestStatus);
-
-    const response = await axiom.ingestRaw('test', JSON.stringify(query), ContentType.JSON, ContentEncoding.Identity);
-    expect(response).toBeDefined();
-    expect(response.ingested).toEqual(2);
-    expect(response.failed).toEqual(0);
-  });
-
-  it('Query', async () => {
-    mockFetchResponse(queryLegacyResult);
-
-    // works without options
-    let query = {
-      startTime: '2020-11-26T11:18:00Z',
-      endTime: '2020-11-17T11:18:00Z',
-      resolution: 'auto',
-    };
-    let response = await axiom.queryLegacy('test', query);
-    expect(response).toBeDefined();
-    expect(response.matches).toHaveLength(2);
-
-    // works with options
-    query = {
-      startTime: '2020-11-26T11:18:00Z',
-      endTime: '2020-11-17T11:18:00Z',
-      resolution: 'auto',
-    };
-    const options = {
-      streamingDuration: '1m',
-      noCache: true,
-    };
-
-    mockFetchResponse(queryLegacyResult);
-    response = await axiom.queryLegacy('test', query, options);
-    expect(response).toBeDefined();
-    expect(response.matches).toHaveLength(2);
-  });
-
-  it('APL Query', async () => {
-    mockFetchResponse(queryResult);
-    // works without options
-    let response = await axiom.query("['test'] | where response == 304");
-    expect(response).not.toEqual('undefined');
-    expect(response.matches).toHaveLength(2);
-
-    // works with options
-    const options = {
-      streamingDuration: '1m',
-      noCache: true,
-    };
-
-    mockFetchResponse(queryResult);
-    response = await axiom.query("['test'] | where response == 304", options);
-    expect(response).not.toEqual('undefined');
-    expect(response.matches).toHaveLength(2);
-  });
-
-  it('catch fetch errors correctly', async () => {
-    let errorCaptured = false;
-    let client = new Axiom({ url: clientURL, token: 'test', onError: (err) => {
-      console.log('callback has been called', err);
-      errorCaptured = true;
-    } });
-    mockFetchResponseErr();
-
-    client.ingest('test', [{ name: 'test' }]);
-    client.ingest('test', [{ name: 'test' }]);
-    await client.flush();
-    expect(true).toEqual(errorCaptured);
-  }, 50000)
 });

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/pino",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.2",
   "description": "The official Axiom transport for Pino",
   "type": "module",
   "types": "dist/esm/types/index.d.ts",

--- a/packages/winston/package.json
+++ b/packages/winston/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/winston",
     "description": "The official Axiom transport for winston logger",
-    "version": "1.0.0-rc.1",
+    "version": "1.0.0-rc.2",
     "type": "module",
     "types": "dist/esm/types/index.d.ts",
     "module": "dist/esm/index.js",


### PR DESCRIPTION
Allow the users to pass a method `onError` to capture and handle errors.