### PR TITLE
Fix type issues by upgrading fetch-retry from 5.0.3 to 6.00

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -43,7 +43,7 @@
     },
     "homepage": "https://github.com/axiomhq/axiom-js/blob/main/packages/js/README.md",
     "dependencies": {
-        "fetch-retry": "^5.0.3",
+        "fetch-retry": "^6.0.0",
         "uuid": "^8.3.2"
     },
     "exports": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
   packages/js:
     dependencies:
       fetch-retry:
-        specifier: ^5.0.3
-        version: 5.0.6
+        specifier: ^6.0.0
+        version: 6.0.0
       uuid:
         specifier: ^8.3.2
         version: 8.3.2
@@ -2391,8 +2391,8 @@ packages:
   /fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
 
-  /fetch-retry@5.0.6:
-    resolution: {integrity: sha512-3yurQZ2hD9VISAhJJP9bpYFNQrHHBXE2JxxjY5aLEcDi46RmAzJE2OC9FAde0yis5ElW0jTTzs0zfg/Cca4XqQ==}
+  /fetch-retry@6.0.0:
+    resolution: {integrity: sha512-BUFj1aMubgib37I3v4q78fYo63Po7t4HUPTpQ6/QE6yK6cIQrP+W43FYToeTEyg5m2Y7eFUtijUuAv/PDlWuag==}
     dev: false
 
   /fflate@0.7.4:


### PR DESCRIPTION
The old version can cause several issues with types when used in a non-browser environment. For me, it's causing [type errors in a cloudflare workers project](https://github.com/cloudflare/workerd/issues/1775).

See https://github.com/jonbern/fetch-retry/pull/88 for details.
