### PR TITLE
fix: add safe stringify to format winston events

### DIFF
--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -221,6 +221,16 @@ export class Axiom extends BaseClient {
   };
 }
 
+declare global {
+  interface BigInt {
+    toJSON: () => string;
+  }
+}
+
+BigInt.prototype.toJSON = function () {
+  return this.toString();
+};
+
 export enum ContentType {
   JSON = 'application/json',
   NDJSON = 'application/x-ndjson',

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -148,6 +148,28 @@ describe('Axiom', () => {
       expect(response.failed).toEqual(0);
     });
 
+    it('IngestBigInt', async () => {
+      const query = [{ foo: 1n }, { bar: 2n }];
+
+      const ingestStatus = {
+        ingested: 2,
+        failed: 0,
+        failures: [],
+        processedBytes: 630,
+        blocksCreated: 0,
+        walLength: 2,
+      };
+      testMockedFetchCall((_: string, init: RequestInit) => {
+        expect(init.headers).toHaveProperty('Content-Type');
+        expect(init.body).toMatch(JSON.stringify(query));
+      }, ingestStatus);
+
+      const response = await axiom.ingestRaw('test', JSON.stringify(query), ContentType.JSON, ContentEncoding.Identity);
+      expect(response).toBeDefined();
+      expect(response.ingested).toEqual(2);
+      expect(response.failed).toEqual(0);
+    });
+
     it('does not throw exception on ingest (50x failure)', async () => {
       let client = new AxiomWithoutBatching({ url: clientURL, token: 'test' })
       mockFetchResponseErr();


### PR DESCRIPTION
**Issue:** Current `JSON.stringify` doesn't support bigints. This results in logs not being sent to Axiom.

**Solution:** Implement `toJSON` function in BigInt prototype so they can be stringified.