### PR TITLE
feate(js): Add referrer opt to dataset creation

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@axiomhq/js",
     "description": "The official javascript bindings for the Axiom API",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "author": "Axiom, Inc.",
     "license": "MIT",
     "contributors": [

--- a/packages/js/src/datasets.ts
+++ b/packages/js/src/datasets.ts
@@ -26,6 +26,10 @@ export namespace datasets {
     description?: string;
   }
 
+  export interface CreateOptions {
+    referrer?: string;
+  }
+
   export interface UpdateRequest {
     description: string;
   }
@@ -41,7 +45,12 @@ export namespace datasets {
 
     get = (id: string): Promise<Dataset> => this.client.get(this.localPath + '/' + id);
 
-    create = (req: CreateRequest): Promise<Dataset> => this.client.post(this.localPath, { body: JSON.stringify(req) });
+    create = (req: CreateRequest, opts?: CreateOptions): Promise<Dataset> => {
+      const params = new URLSearchParams();
+      params.set('referrer', opts?.referrer ?? '');
+      let path = `/v2/datasets?${params.toString()}`;
+      return this.client.post(path, { body: JSON.stringify(req) });
+    };
 
     update = (id: string, req: UpdateRequest): Promise<Dataset> =>
       this.client.put(this.localPath + '/' + id, { body: JSON.stringify(req) });

--- a/turbo.json
+++ b/turbo.json
@@ -28,8 +28,7 @@
         "integration": {
             "dependsOn": [
                 "^build",
-                "^build:cjs",
-                "^test"
+                "^build:cjs"
             ]
         },
         "e2e": {


### PR DESCRIPTION
This upgrades the create dataset fn to v2 and adds an optional referrer arg. 

It also removes the dep on `test` from `integration` in `turbo.json`.