### PR TITLE
Make flush() public

### DIFF
--- a/packages/winston/src/index.ts
+++ b/packages/winston/src/index.ts
@@ -58,7 +58,7 @@ export class WinstonTransport extends Transport {
     }
   }
 
-  private flush(callback: (err: Error | null) => void = () => {}) {
+  flush(callback: (err: Error | null) => void = () => {}) {
     const batchCopy = this.batch.slice();
 
     clearTimeout(this.batchTimeoutId);


### PR DESCRIPTION
The support team send me this sample but it can't work `ts: Property 'flush' is private and only accessible within class 'WinstonTransport'.`


```ts
  // Ensure logs are flushed before the process exits
  process.on('beforeExit', () => {
    axiomTransport
      .flush()
      .then(() => {
        console.log('Logs flushed successfully');
      })
      .catch((error) => {
        console.error('Error flushing logs:', error);
      });
  });
}
```