### PR TITLE
feat: warn when using personal tokens in axiom-js

### DIFF
--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -11,7 +11,7 @@ class BaseClient extends HTTPClient {
   onError = console.error;
 
   constructor(options: ClientOptions) {
-    if (isAxiomPersonalToken(options.token)) {
+    if (options.token && isAxiomPersonalToken(options.token)) {
       console.warn(
         'Using a personal token (`xapt-...`) is deprecated for security reasons. Please use an API token (`xaat-...`) instead. Support for personal tokens will be removed in a future release.',
       );

--- a/packages/js/src/token.ts
+++ b/packages/js/src/token.ts
@@ -1,0 +1,7 @@
+export function isAxiomPersonalToken(token: string): boolean {
+  if (token.startsWith('xapt')) {
+    return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
- autofix some prettier issues (we should probably follow up by running it on the whole project and including a check in ci)
- warn in console when creating `Axiom` or `AxiomWithoutBatching` with a personal token (`xapt-*`)
  - ...and tests to ensure this works
- in a future release we will completely disallow using personal tokens