### PR TITLE
Add New Config Flag to Disable fetch `cache` Option

### DIFF
--- a/packages/js/src/fetchClient.ts
+++ b/packages/js/src/fetchClient.ts
@@ -2,7 +2,9 @@ import fetchRetry from 'fetch-retry';
 import { parseLimitFromResponse, Limit, LimitType } from './limit.js';
 
 export class FetchClient {
-  constructor(public config: { headers: HeadersInit; baseUrl: string; timeout: number }) {}
+  constructor(
+    public config: { headers: HeadersInit; baseUrl: string; timeout: number; disableFetchCashNoStore: boolean },
+  ) {}
 
   async doReq<T>(
     endpoint: string,
@@ -29,7 +31,7 @@ export class FetchClient {
       method,
       body: init.body ? init.body : undefined,
       signal: AbortSignal.timeout(timeout),
-      cache: 'no-cache',
+      ...(this.config.disableFetchCacheNoStore ? {} : { cache: 'no-cache' }),
     });
 
     if (resp.status === 204) {

--- a/packages/js/src/httpClient.ts
+++ b/packages/js/src/httpClient.ts
@@ -31,13 +31,19 @@ export interface ClientOptions {
    * need to change this unless you are using a self-hosted version of Axiom.
    */
   url?: string;
+  /**
+   * Disables the cache for the request, defaults to false.
+   * Fixes Cloudflare compatibility issue:
+   * https://developers.cloudflare.com/workers/configuration/compatibility-flags/#enable-cache-no-store-http-standard-api
+   */
+  disableFetchCacheNoStore?: boolean;
   onError?: (error: Error) => void;
 }
 
 export default abstract class HTTPClient {
   protected readonly client: FetchClient;
 
-  constructor({ orgId = '', token, url }: ClientOptions) {
+  constructor({ orgId = '', token, url, disableFetchCacheNoStore }: ClientOptions) {
     if (!token) {
       console.warn('Missing Axiom token');
     }
@@ -60,6 +66,7 @@ export default abstract class HTTPClient {
       baseUrl,
       headers,
       timeout: 20_000,
+      disableFetchCacheNoStore,
     });
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/axiomhq/axiom-js/issues/242

Not sure if this is the best route to fix this issue, but I figured it was a quick commit so I might as well propose it.