### PR TITLE
fix: set cache to no-store instead of no-cache

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axiomhq/js",
   "description": "The official javascript bindings for the Axiom API",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/packages/js/src/fetchClient.ts
+++ b/packages/js/src/fetchClient.ts
@@ -29,7 +29,7 @@ export class FetchClient {
       method,
       body: init.body ? init.body : undefined,
       signal: AbortSignal.timeout(timeout),
-      cache: 'no-cache',
+      cache: 'no-store',
     });
 
     if (resp.status === 204) {

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/pino",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "The official Axiom transport for Pino",
   "type": "module",
   "types": "dist/esm/types/index.d.ts",

--- a/packages/winston/package.json
+++ b/packages/winston/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axiomhq/winston",
   "description": "The official Axiom transport for winston logger",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "type": "module",
   "types": "dist/esm/types/index.d.ts",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
This fix closes #246; Cloudflare doesn't support no-cache value so this change sets cache to 'no-store' instead.