### PR TITLE
feat: add js bindings to /v2/monitors

### DIFF
--- a/examples/js/src/manage-monitors.ts
+++ b/examples/js/src/manage-monitors.ts
@@ -1,0 +1,77 @@
+import { monitors } from '@axiomhq/js';
+
+const client = new monitors.Service({ token: process.env.AXIOM_TOKEN || '' });
+const datasetName = 'test-axiom-js-monitors';
+
+async function createMonitor() {
+  console.log('Creating monitor...');
+  const response = await client.create({
+    name: 'Example CPU Monitor',
+    type: 'Threshold',
+    description: 'Monitor high CPU usage',
+    aplQuery: `['${datasetName}'] | summarize count() by bin_auto(_time)`,
+    operator: 'Above',
+    threshold: 90,
+    alertOnNoData: true,
+    notifyByGroup: false,
+    notifierIDs: [],
+    intervalMinutes: 5,
+    rangeMinutes: 10,
+  });
+  console.log(`Created monitor with ID: ${response.id}`);
+  return response;
+}
+
+async function listMonitors() {
+  console.log('\nListing all monitors:');
+  const monitors = await client.list();
+  for (const monitor of monitors) {
+    console.log(`- ${monitor.name} (${monitor.id}): ${monitor.description}`);
+  }
+  return monitors;
+}
+
+async function getMonitor(id: string) {
+  console.log(`\nGetting monitor ${id}...`);
+  const response = await client.get(id);
+  console.log(`Retrieved monitor: ${JSON.stringify(response, null, 2)}`);
+  return response;
+}
+
+async function updateMonitor(id: string) {
+  console.log('\nUpdating monitor...');
+  const response = await client.update(id, {
+    name: 'Updated CPU Monitor',
+    type: 'Threshold',
+    description: 'Monitor high CPU usage',
+    aplQuery: `['${datasetName}'] | summarize count() by bin_auto(_time)`,
+    operator: 'Above',
+    threshold: 90,
+    alertOnNoData: true,
+    notifyByGroup: false,
+    notifierIDs: [],
+    intervalMinutes: 5,
+
+    rangeMinutes: 10,
+  });
+  console.log(`Updated monitor name to: ${response.name}`);
+  return response;
+}
+
+async function deleteMonitor(id: string) {
+  console.log('\nDeleting monitor...');
+  const response = await client.delete(id);
+  console.log('Monitor deleted successfully');
+  return response;
+}
+
+async function main() {
+  // Create and manage a monitor
+  const monitor = await createMonitor();
+  await listMonitors();
+  await getMonitor(monitor.id);
+  await updateMonitor(monitor.id);
+  await deleteMonitor(monitor.id);
+}
+
+main().catch(console.error);

--- a/examples/js/src/manage-monitors.ts
+++ b/examples/js/src/manage-monitors.ts
@@ -51,7 +51,6 @@ async function updateMonitor(id: string) {
     notifyByGroup: false,
     notifierIDs: [],
     intervalMinutes: 5,
-
     rangeMinutes: 10,
   });
   console.log(`Updated monitor name to: ${response.name}`);

--- a/integration/src/monitors.spec.ts
+++ b/integration/src/monitors.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it, beforeAll, afterAll } from 'vitest';
+import { monitors, datasets } from '@axiomhq/js';
+
+const datasetSuffix = process.env.AXIOM_DATASET_SUFFIX || 'local';
+
+describe('MonitorsService', () => {
+  const datasetName = `test-axiom-js-datasets-${datasetSuffix}`;
+  const datasetsClient = new datasets.Service({
+    token: process.env.AXIOM_TOKEN || '',
+    url: process.env.AXIOM_URL,
+    orgId: process.env.AXIOM_ORG_ID,
+  });
+  const client = new monitors.Service({
+    token: process.env.AXIOM_TOKEN || '',
+    orgId: process.env.AXIOM_ORG_ID,
+  });
+
+  let monitorId = '';
+
+  beforeAll(async () => {
+    await datasetsClient.create({
+      name: datasetName,
+      description: 'This is a test dataset to be used for annotations testing',
+    });
+  });
+
+  afterAll(async () => {
+    const resp = await datasetsClient.delete(datasetName);
+    expect(resp.status).toEqual(204);
+  });
+
+  it('Create', async () => {
+    const request: monitors.CreateRequest = {
+      name: 'Integration Test Monitor',
+      type: 'Threshold',
+      description: 'Monitor created by integration test',
+      aplQuery: `['${datasetName}'] | summarize count() by bin_auto(_time)`,
+      operator: 'Above',
+      threshold: 100,
+      alertOnNoData: false,
+      notifyByGroup: false,
+      notifierIDs: [],
+      intervalMinutes: 5,
+      rangeMinutes: 10,
+    };
+
+    const response = await client.create(request);
+    expect(response).toBeDefined();
+    expect(response.name).toEqual(request.name);
+    expect(response.description).toEqual(request.description);
+    expect(response.type).toEqual(request.type);
+    expect(response.threshold).toEqual(request.threshold);
+
+    monitorId = response.id;
+  });
+
+  it('Get', async () => {
+    const response = await client.get(monitorId);
+    expect(response).toBeDefined();
+    expect(response.id).toEqual(monitorId);
+    expect(response.name).toEqual('Integration Test Monitor');
+  });
+
+  it('List', async () => {
+    const response = await client.list();
+    expect(response).toBeDefined();
+    expect(response.length).toBeGreaterThan(0);
+    expect(response.find((m: monitors.Monitor) => m.id === monitorId)).toBeDefined();
+  });
+
+  it('Update', async () => {
+    const request: monitors.UpdateRequest = {
+      name: 'Updated Integration Test Monitor',
+      type: 'Threshold',
+      description: 'Updated monitor description',
+      aplQuery: `['${datasetName}'] | summarize count() by bin_auto(_time)`,
+      operator: 'Above',
+      threshold: 150,
+      alertOnNoData: false,
+      notifyByGroup: false,
+      notifierIDs: [],
+      intervalMinutes: 5,
+      rangeMinutes: 10,
+    };
+
+    const response = await client.update(monitorId, request);
+    expect(response).toBeDefined();
+    expect(response.id).toEqual(monitorId);
+    expect(response.name).toEqual(request.name);
+    expect(response.description).toEqual(request.description);
+    expect(response.threshold).toEqual(request.threshold);
+  });
+
+  it('Delete', async () => {
+    const response = await client.delete(monitorId);
+    expect(response).toBeDefined();
+    expect(response.status).toEqual(204);
+
+    // Verify the monitor is actually deleted
+    try {
+      const fetchResponse = await client.get(monitorId);
+      expect(fetchResponse).toBeUndefined();
+    } catch (error) {
+      expect(error).toBeDefined();
+    }
+  });
+});

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -28,8 +28,9 @@ export {
   Status,
   Message,
   Query,
-} from "./client.js";
-export { ClientOptions } from "./httpClient.js";
-export { datasets } from "./datasets.js";
-export { annotations } from "./annotations.js";
-export { users } from "./users.js";
+} from './client.js';
+export { ClientOptions } from './httpClient.js';
+export { datasets } from './datasets.js';
+export { annotations } from './annotations.js';
+export { users } from './users.js';
+export { monitors } from './monitors.js';

--- a/packages/js/src/monitors.ts
+++ b/packages/js/src/monitors.ts
@@ -24,7 +24,7 @@ export namespace monitors {
     disabledUntil?: string;
   }
 
-  export interface CreateRequest {
+  export interface CreateRequest extends Omit<Monitor, 'id' | 'createdAt' | 'createdBy'> {
     name: string;
     type: MonitorType;
     description?: string;
@@ -42,18 +42,18 @@ export namespace monitors {
   }
 
   export interface UpdateRequest {
-    name?: string;
-    type?: MonitorType;
+    name: string;
+    type: MonitorType;
     description?: string;
-    aplQuery?: string;
-    operator?: MonitorOperator;
-    threshold?: number;
-    alertOnNoData?: boolean;
-    notifyByGroup?: boolean;
+    aplQuery: string;
+    operator: MonitorOperator;
+    threshold: number;
+    alertOnNoData: boolean;
+    notifyByGroup: boolean;
     resolvable?: boolean;
-    notifierIDs?: string[];
-    intervalMinutes?: number;
-    rangeMinutes?: number;
+    notifierIDs: string[];
+    intervalMinutes: number;
+    rangeMinutes: number;
     disabled?: boolean;
     disabledUntil?: string;
   }

--- a/packages/js/src/monitors.ts
+++ b/packages/js/src/monitors.ts
@@ -24,39 +24,9 @@ export namespace monitors {
     disabledUntil?: string;
   }
 
-  export interface CreateRequest extends Omit<Monitor, 'id' | 'createdAt' | 'createdBy'> {
-    name: string;
-    type: MonitorType;
-    description?: string;
-    aplQuery: string;
-    operator: MonitorOperator;
-    threshold: number;
-    alertOnNoData: boolean;
-    notifyByGroup: boolean;
-    resolvable?: boolean;
-    notifierIDs: string[];
-    intervalMinutes: number;
-    rangeMinutes: number;
-    disabled?: boolean;
-    disabledUntil?: string;
-  }
+  export interface CreateRequest extends Omit<Monitor, 'id' | 'createdAt' | 'createdBy'> {}
 
-  export interface UpdateRequest {
-    name: string;
-    type: MonitorType;
-    description?: string;
-    aplQuery: string;
-    operator: MonitorOperator;
-    threshold: number;
-    alertOnNoData: boolean;
-    notifyByGroup: boolean;
-    resolvable?: boolean;
-    notifierIDs: string[];
-    intervalMinutes: number;
-    rangeMinutes: number;
-    disabled?: boolean;
-    disabledUntil?: string;
-  }
+  export interface UpdateRequest extends Omit<Monitor, 'id' | 'createdAt' | 'createdBy'> {}
 
   export class Service extends HTTPClient {
     private readonly localPath = '/v2/monitors';

--- a/packages/js/src/monitors.ts
+++ b/packages/js/src/monitors.ts
@@ -1,0 +1,75 @@
+import HTTPClient from './httpClient.js';
+
+export namespace monitors {
+  export type MonitorType = 'Threshold' | 'MatchEvent';
+  export type MonitorOperator = 'Below' | 'BelowOrEqual' | 'Above' | 'AboveOrEqual';
+
+  export interface Monitor {
+    id: string;
+    createdAt: string;
+    createdBy: string;
+    name: string;
+    type: MonitorType;
+    description?: string;
+    aplQuery: string;
+    operator: MonitorOperator;
+    threshold: number;
+    alertOnNoData: boolean;
+    notifyByGroup: boolean;
+    resolvable?: boolean;
+    notifierIDs: string[];
+    intervalMinutes: number;
+    rangeMinutes: number;
+    disabled?: boolean;
+    disabledUntil?: string;
+  }
+
+  export interface CreateRequest {
+    name: string;
+    type: MonitorType;
+    description?: string;
+    aplQuery: string;
+    operator: MonitorOperator;
+    threshold: number;
+    alertOnNoData: boolean;
+    notifyByGroup: boolean;
+    resolvable?: boolean;
+    notifierIDs: string[];
+    intervalMinutes: number;
+    rangeMinutes: number;
+    disabled?: boolean;
+    disabledUntil?: string;
+  }
+
+  export interface UpdateRequest {
+    name?: string;
+    type?: MonitorType;
+    description?: string;
+    aplQuery?: string;
+    operator?: MonitorOperator;
+    threshold?: number;
+    alertOnNoData?: boolean;
+    notifyByGroup?: boolean;
+    resolvable?: boolean;
+    notifierIDs?: string[];
+    intervalMinutes?: number;
+    rangeMinutes?: number;
+    disabled?: boolean;
+    disabledUntil?: string;
+  }
+
+  export class Service extends HTTPClient {
+    private readonly localPath = '/v2/monitors';
+
+    list = (): Promise<Monitor[]> => this.client.get(this.localPath);
+
+    get = (id: string): Promise<Monitor> => this.client.get(this.localPath + '/' + id);
+
+    create = (req: CreateRequest): Promise<Monitor> => this.client.post(this.localPath, { body: JSON.stringify(req) });
+
+    update = (id: string, req: UpdateRequest): Promise<Monitor> =>
+      this.client.put(this.localPath + '/' + id, { body: JSON.stringify(req) });
+
+    delete = (id: string): Promise<Response> => this.client.delete(this.localPath + '/' + id);
+  }
+}

--- a/packages/js/test/unit/monitors.test.ts
+++ b/packages/js/test/unit/monitors.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import { monitors } from '../../src/monitors';
+import { mockFetchResponse, mockNoContentResponse } from '../lib/mock';
+
+const monitorsList: monitors.Monitor[] = [
+  {
+    id: 'test1',
+    createdAt: '2025-01-01T00:00:00Z',
+    createdBy: 'user1',
+    name: 'High CPU Usage',
+    type: 'Threshold',
+    description: 'Monitor for high CPU usage',
+    aplQuery: "['system-metrics'] | where cpu > 90 | summarize count() by bin_auto(_time)",
+    operator: 'Above',
+    threshold: 10,
+    alertOnNoData: true,
+    notifyByGroup: false,
+    notifierIDs: ['notifier1'],
+    intervalMinutes: 5,
+    rangeMinutes: 10,
+    disabled: false,
+  },
+  {
+    id: 'test2',
+    createdAt: '2025-01-02T00:00:00Z',
+    createdBy: 'user1',
+    name: 'Error Rate Alert',
+    type: 'MatchEvent',
+    description: 'Monitor for error rate spikes',
+    aplQuery: "['app-logs'] | where level = 'error'",
+    operator: 'Above',
+    threshold: 100,
+    alertOnNoData: false,
+    notifyByGroup: true,
+    resolvable: true,
+    notifierIDs: ['notifier1', 'notifier2'],
+    intervalMinutes: 15,
+    rangeMinutes: 30,
+    disabled: false,
+  },
+];
+
+describe('MonitorsService', () => {
+  const client = new monitors.Service({ url: 'http://axiom-js.dev.local', token: '' });
+
+  it('List', async () => {
+    mockFetchResponse(monitorsList);
+    const response = await client.list();
+    expect(response).not.toEqual('undefined');
+    expect(response).toHaveLength(2);
+  });
+
+  it('Get', async () => {
+    mockFetchResponse(monitorsList[0]);
+    const response = await client.get('test1');
+    expect(response).toBeDefined();
+    expect(response.id).toEqual('test1');
+    expect(response.name).toEqual('High CPU Usage');
+    expect(response.type).toEqual('Threshold');
+  });
+
+  it('Create', async () => {
+    const request: monitors.CreateRequest = {
+      name: 'Memory Usage Alert',
+      type: 'Threshold',
+      description: 'Monitor for memory usage',
+      aplQuery: "['system-metrics'] | where memory > 80",
+      operator: 'Above',
+      threshold: 80,
+      alertOnNoData: true,
+      notifyByGroup: false,
+      notifierIDs: ['notifier1'],
+      intervalMinutes: 5,
+      rangeMinutes: 10,
+    };
+
+    const expectedResponse = {
+      id: 'test3',
+      createdAt: '2025-01-03T00:00:00Z',
+      createdBy: 'user1',
+      ...request,
+    };
+
+    mockFetchResponse(expectedResponse);
+
+    const response = await client.create(request);
+    expect(response).toBeDefined();
+    expect(response.id).toEqual('test3');
+    expect(response.name).toEqual('Memory Usage Alert');
+    expect(response.threshold).toEqual(80);
+  });
+
+  it('Update', async () => {
+    const req: monitors.UpdateRequest = {
+      name: 'Updated CPU Monitor',
+      description: 'Updated description',
+      threshold: 95,
+    };
+
+    const expectedResponse = {
+      ...monitorsList[0],
+      name: 'Updated CPU Monitor',
+      description: 'Updated description',
+      threshold: 95,
+    };
+
+    mockFetchResponse(expectedResponse);
+
+    const response = await client.update('test1', req);
+    expect(response).toBeDefined();
+    expect(response.id).toEqual('test1');
+    expect(response.name).toEqual('Updated CPU Monitor');
+    expect(response.threshold).toEqual(95);
+  });
+
+  it('Delete', async () => {
+    mockNoContentResponse();
+
+    const response = await client.delete('test1');
+    expect(response).toBeDefined();
+    expect(response.status).toEqual(204);
+  });
+});


### PR DESCRIPTION
Adding js bindings to /v2/monitors as discussed in 
- #263 

The changes in this PR closely follow the conventions established throughout the rest of the codebase.

Checklist: 
 - [x] Add JS bindings to /v2/monitors
 - [x] Add monitor unit tests `(test.ts)`
 - [x] Add monitor integration tests `(spec.ts)`
 - [x] Add monitor js usage examples in `/examples/js/src`
 - [x] Manually validate js bindings in Axiom