### PR TITLE
feat: remove any reference to the node:crypto lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ dist
 .vscode
 .envrc
 .turbo
+
+# Extra IDEs folders
+.idea/

--- a/package.json
+++ b/package.json
@@ -64,5 +64,5 @@
     "integration",
     "e2e/*"
   ],
-  "packageManager": "pnpm@10.4.1"
+  "packageManager": "pnpm@10.11.0"
 }

--- a/packages/nextjs/src/lib/node-utils.ts
+++ b/packages/nextjs/src/lib/node-utils.ts
@@ -1,4 +1,27 @@
-const crypto = globalThis.crypto ?? require('node:crypto').webcrypto;
+const crypto = {
+  /**
+   * Try to use the native **crypto** library through globalThis.crypto,
+   * if it's not present, use a less cryptographically secure internal function.
+   *
+   * This is meant to remove any reference to **node:crypto**, as it causes Vercel deployments to fail
+   */
+  randomUUID: () => {
+    if (globalThis.crypto) {
+      return globalThis.crypto.randomUUID();
+    }
+    return generateUUIDv4();
+  },
+};
+
+function generateUUIDv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (char) => {
+    const rand = Math.random() * 16 | 0;
+    const value = char === 'x' ? rand : (rand & 0x3) | 0x8;
+    return value.toString(16);
+  });
+}
+
+
 const AsyncLocalStorage = globalThis.AsyncLocalStorage ?? require('node:async_hooks').AsyncLocalStorage;
 
 export { crypto, AsyncLocalStorage };


### PR DESCRIPTION
this PR removes the reference to the node:crypto module, this is to solve an issue with Vercel deployments (with Next v15) where if the app has a middleware any deployments will fail

https://github.com/axiomhq/axiom-js/issues/283#issuecomment-2796002954