### PR TITLE
add cursor option to query call

### DIFF
--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -128,6 +128,7 @@ class BaseClient extends HTTPClient {
           'streaming-duration': options?.streamingDuration as string,
           nocache: options?.noCache as boolean,
           format: options?.format ?? 'legacy',
+          cursor: options?.cursor as string,
         },
         120_000,
       )
@@ -363,6 +364,7 @@ export interface QueryOptions extends QueryOptionsBase {
   startTime?: string;
   endTime?: string;
   format?: 'legacy' | 'tabular';
+  cursor?: string;
 }
 
 export interface QueryLegacy {


### PR DESCRIPTION
Hello,
For my specific use case, I needed pagination for query call (tabular version, not the legacy one).

I see, your documentation on the subject:
https://axiom.co/docs/restapi/pagination#cursor-based-pagination

Unfortunately, it seems that the axiom-js client does not implement the cursor option for the query call ?
(Whereas for the legacy query call, the cursor option is available)

So, I added the option cursor in QueryOptions