### PR TITLE
ci: disable git checks on publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --frozen-lockfile
       - run: pnpm build && pnpm build:cjs
-      - run: pnpm publish --access public --filter "./packages/**"
+      - run: pnpm publish --access public --filter "./packages/**" --no-git-checks
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTOMATION_TOKEN }}


### PR DESCRIPTION
The pnpm publish command is failing with the following error:

```
Run pnpm publish --access public --filter "./packages/**"
 ERR_PNPM_GIT_UNCLEAN  Unclean working tree. Commit or stash changes first.

If you want to disable Git checks on publish, set the "git-checks" setting to "false", or run again with "--no-git-checks".
```