### PR TITLE
fix(js): overall batching logic

### DIFF
--- a/packages/js/src/batch.ts
+++ b/packages/js/src/batch.ts
@@ -1,72 +1,207 @@
 import { IngestOptions, IngestStatus } from "./client.js";
 
+/**
+ * Transport callback used by {@link Batch} to send queued events.
+ */
 export type IngestFunction = (
   id: string,
   events: Array<object> | object,
   options?: IngestOptions,
 ) => Promise<IngestStatus>;
 
+/**
+ * Runtime configuration for a {@link Batch} instance.
+ */
+export interface BatchConfig {
+  /**
+   * Maximum number of queued events before triggering an immediate flush.
+   * @defaultValue 1000
+   */
+  maxBatchSize?: number;
+  /**
+   * Maximum time in milliseconds between successful flush attempts.
+   * @defaultValue 1000
+   */
+  flushIntervalMs?: number;
+  /**
+   * Error hook used for background flush failures.
+   */
+  onError?: (error: unknown) => void;
+  /**
+   * Clock function used for flush timing; primarily useful for tests.
+   */
+  now?: () => number;
+}
+
+/**
+ * Internal batch lifecycle state.
+ */
+export type BatchState = "idle" | "scheduled" | "flushing";
+
+const DEFAULT_MAX_BATCH_SIZE = 1000;
+const DEFAULT_FLUSH_INTERVAL_MS = 1000;
+
+/**
+ * Builds a deterministic key for grouping events into a single batch queue.
+ *
+ * The key includes dataset identity and ingest options that influence server
+ * parsing so incompatible payloads do not share the same queue.
+ */
 export function createBatchKey(id: string, options?: IngestOptions): string {
   return `${id}:${options?.timestampField || "-"}:${options?.timestampFormat || "-"}:${options?.csvDelimiter || "-"}`;
 }
 
+/**
+ * In-memory FIFO event queue with time/size-based flushing.
+ *
+ * Events are buffered and flushed either when enough events have accumulated or
+ * when the flush interval elapses. Flushes are serialized to preserve ordering.
+ */
 export class Batch {
   ingestFn: IngestFunction;
   id: string;
   options?: IngestOptions;
 
   events: Array<object> = [];
+  state: BatchState = "idle";
 
   activeFlush: Promise<IngestStatus | void> = Promise.resolve();
-  nextFlush: NodeJS.Timeout = setTimeout(() => {}, 0);
+  nextFlush?: ReturnType<typeof setTimeout>;
   lastFlush: Date = new Date();
 
-  constructor(ingestFn: IngestFunction, id: string, options?: IngestOptions) {
+  private maxBatchSize: number;
+  private flushIntervalMs: number;
+  private onError?: (error: unknown) => void;
+  private now: () => number;
+
+  /**
+   * Creates a background batch queue for one dataset/options combination.
+   */
+  constructor(ingestFn: IngestFunction, id: string, options?: IngestOptions, config?: BatchConfig) {
     this.ingestFn = ingestFn;
     this.id = id;
     this.options = options;
+    this.maxBatchSize = config?.maxBatchSize ?? DEFAULT_MAX_BATCH_SIZE;
+    this.flushIntervalMs = config?.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+    this.onError = config?.onError;
+    this.now = config?.now ?? Date.now;
   }
 
+  /**
+   * Appends event(s) to the queue and triggers or schedules a flush.
+   *
+   * This method is intentionally fire-and-forget. Background flush failures are
+   * reported through the configured `onError` callback.
+   */
   ingest = (events: Array<object> | object) => {
-    if (Array.isArray(events)) {
-      this.events = this.events.concat(events);
-    } else {
-      this.events.push(events);
-    }
+    this.enqueue(events);
 
-    if (this.events.length >= 1000 || this.lastFlush.getTime() < Date.now() - 1000) {
-      // We either have more than 1k events or the last flush was more than 1s ago
-      clearTimeout(this.nextFlush);
-      this.activeFlush = this.flush();
-    } else {
-      // Create a timeout so we flush remaining events even if no more come in
-      clearTimeout(this.nextFlush);
-      this.nextFlush = setTimeout(() => {
-        this.activeFlush = this.flush();
-      }, 1000);
-    }
-  };
-
-  flush = async (): Promise<IngestStatus | undefined> => {
-    const events = this.events.splice(0, this.events.length);
-
-    clearTimeout(this.nextFlush);
-    await this.activeFlush;
-
-    if (events.length === 0) {
-      this.lastFlush = new Date(); // we tried
+    if (this.shouldFlushNow()) {
+      this.startBackgroundFlush();
       return;
     }
 
-    let res = null;
-    try {
-      res = await this.ingestFn(this.id, events, this.options);
-    } catch (e) {
-      throw e;
-    } finally {
-      this.lastFlush = new Date();
+    this.scheduleFlush();
+  };
+
+  /**
+   * Flushes currently queued events and resolves when this flush finishes.
+   *
+   * Flushes are serialized with any in-flight flush to avoid concurrent sends.
+   */
+  flush = async (): Promise<IngestStatus | undefined> => {
+    const events = this.drainEvents();
+    this.clearScheduledFlush();
+    const previousFlush = this.activeFlush;
+
+    const flushPromise = (async (): Promise<IngestStatus | undefined> => {
+      this.state = "flushing";
+      // Keep flushes serialized but don't allow previous failures to poison
+      // all future flushes.
+      await previousFlush.catch(() => undefined);
+
+      if (events.length === 0) {
+        this.lastFlush = new Date(this.now());
+        if (this.state !== "scheduled") {
+          this.state = "idle";
+        }
+        return;
+      }
+
+      try {
+        return await this.ingestFn(this.id, events, this.options);
+      } finally {
+        this.lastFlush = new Date(this.now());
+        if (this.state !== "scheduled") {
+          this.state = "idle";
+        }
+      }
+    })();
+
+    this.activeFlush = flushPromise;
+    return await flushPromise;
+  };
+
+  /**
+   * Appends events to the queue while preserving FIFO order.
+   */
+  private enqueue = (events: Array<object> | object) => {
+    if (Array.isArray(events)) {
+      this.events.push(...events);
+      return;
     }
 
-    return res;
+    this.events.push(events);
+  };
+
+  /**
+   * Drains the current queue in O(1) by swapping array references.
+   */
+  private drainEvents = (): Array<object> => {
+    const events = this.events;
+    this.events = [];
+    return events;
+  };
+
+  /**
+   * Returns true when queue size or elapsed time requires an immediate flush.
+   */
+  private shouldFlushNow = (): boolean => {
+    return this.events.length >= this.maxBatchSize || this.lastFlush.getTime() < this.now() - this.flushIntervalMs;
+  };
+
+  /**
+   * Schedules a deferred flush to ensure low-volume traffic is eventually sent.
+   */
+  private scheduleFlush = () => {
+    this.clearScheduledFlush();
+    this.state = "scheduled";
+
+    this.nextFlush = setTimeout(() => {
+      this.startBackgroundFlush();
+    }, this.flushIntervalMs);
+  };
+
+  /**
+   * Starts a flush without awaiting it and forwards failures to `onError`.
+   */
+  private startBackgroundFlush = () => {
+    const flushPromise = this.flush();
+    void flushPromise.catch((error) => {
+      this.onError?.(error);
+      return;
+    });
+  };
+
+  /**
+   * Cancels a pending timer-based flush, if one exists.
+   */
+  private clearScheduledFlush = () => {
+    if (!this.nextFlush) {
+      return;
+    }
+
+    clearTimeout(this.nextFlush);
+    this.nextFlush = undefined;
   };
 }

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -337,6 +337,7 @@ export class Axiom extends BaseClient {
         },
         dataset,
         options,
+        { onError: this.onError },
       );
     }
     return this.batch[key].ingest(events);

--- a/packages/js/test/unit/batch.test.ts
+++ b/packages/js/test/unit/batch.test.ts
@@ -117,4 +117,65 @@ describe("Batch", () => {
     // Make sure we ingested both events
     expect(sentEvents).toEqual([{ foo: "bar" }, { foo: "baz" }]);
   });
+
+  it("doesn't get stuck after a rejected flush", async () => {
+    const sendFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ ingested: 1, failed: 0, processedBytes: 0, blocksCreated: 0, walLength: 0 });
+
+    const batch = new Batch(sendFn, "my-dataset", { timestampField: "foo" });
+
+    batch.ingest({ foo: "first" });
+    await expect(batch.flush()).rejects.toThrow("boom");
+
+    batch.ingest({ foo: "second" });
+    await expect(batch.flush()).resolves.toEqual({
+      ingested: 1,
+      failed: 0,
+      processedBytes: 0,
+      blocksCreated: 0,
+      walLength: 0,
+    });
+
+    expect(sendFn).toHaveBeenCalledTimes(2);
+    expect(sendFn).toHaveBeenNthCalledWith(1, "my-dataset", [{ foo: "first" }], { timestampField: "foo" });
+    expect(sendFn).toHaveBeenNthCalledWith(2, "my-dataset", [{ foo: "second" }], { timestampField: "foo" });
+    expect(batch.events).toEqual([]);
+  });
+
+  it("reports background flush errors and continues flushing", async () => {
+    const onError = vi.fn();
+    const sendFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("boom"))
+      .mockResolvedValueOnce({ ingested: 1, failed: 0, processedBytes: 0, blocksCreated: 0, walLength: 0 });
+
+    const batch = new Batch(sendFn, "my-dataset", { timestampField: "foo" }, { maxBatchSize: 1, onError });
+
+    batch.ingest({ foo: "first" });
+    await sleep(10);
+
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    batch.ingest({ foo: "second" });
+    await batch.flush();
+
+    expect(sendFn).toHaveBeenCalledTimes(2);
+    expect(sendFn).toHaveBeenNthCalledWith(2, "my-dataset", [{ foo: "second" }], { timestampField: "foo" });
+  });
+
+  it("supports configurable flush thresholds", async () => {
+    const sendFn = vi.fn() as IngestFunction;
+    const batch = new Batch(sendFn, "my-dataset", { timestampField: "foo" }, { maxBatchSize: 2, flushIntervalMs: 20 });
+
+    batch.ingest({ foo: "bar" });
+    await sleep(5);
+    expect(sendFn).toHaveBeenCalledTimes(0);
+
+    batch.ingest({ foo: "baz" });
+    await sleep(20);
+    expect(sendFn).toHaveBeenCalledTimes(1);
+    expect(sendFn).toHaveBeenCalledWith("my-dataset", [{ foo: "bar" }, { foo: "baz" }], { timestampField: "foo" });
+  });
 });


### PR DESCRIPTION
## Bug fix: recover from rejected flushes

`Batch.flush()` used to drain queued events first and then wait for the previous flush promise.
If the previous flush rejected, that wait would throw before the newly drained events were sent.

### Before

```ts
flush = async (): Promise<IngestStatus | undefined> => {
  const events = this.events.splice(0, this.events.length);

  clearTimeout(this.nextFlush);
  await this.activeFlush; // throws if previous flush rejected doesn't get reassigned and get's stuck here

  if (events.length === 0) {
    this.lastFlush = new Date();
    return;
  }

  return await this.ingestFn(this.id, events, this.options);
};
```

### Why this breaks

```ts
// T1: previous flush fails -> this.activeFlush = Promise.reject(...)
// T2: new events arrive and are drained into `events`
// T3: await this.activeFlush throws immediately
// => drained events are never sent, and activeFlush stays rejected
```

That creates two issues:
- drained events can be dropped on the floor
- subsequent flushes keep short-circuiting on the same rejected promise ("poisoned" queue)

### After 
```ts
flush = async (): Promise<IngestStatus | undefined> => {
  const events = this.drainEvents();
  this.clearScheduledFlush();
  const previousFlush = this.activeFlush;

  const flushPromise = (async () => {
    await previousFlush.catch(() => undefined); // preserve sequencing, ignore prior rejection here

    if (events.length === 0) {
      this.lastFlush = new Date(this.now());
      return;
    }

    return await this.ingestFn(this.id, events, this.options);
  })();

  this.activeFlush = flushPromise;
  return await flushPromise;
};
```

### Background error handling improvement

```ts
private startBackgroundFlush = () => {
  const flushPromise = this.flush();
  void flushPromise.catch((error) => {
    this.onError?.(error);
  });
};
```

This avoids unhandled promise rejections when `ingest()` triggers fire-and-forget flushes.

## Other improvements
- Refactored batch scheduling logic into explicit helper methods.
- Added configurable batch thresholds (`maxBatchSize`, `flushIntervalMs`) and lifecycle state metadata.
- Added API-focused JSDoc comments in `batch.ts`.
- Added regression tests for:
  - rejected-flush recovery
  - background error handling
  - configurable thresholds

## Testing
- `pnpm --filter @axiomhq/js test`
- `pnpm --filter @axiomhq/js exec vitest run test/unit/batch.test.ts`
