### PR TITLE
fix(logging): prevent FetchTransport crash on circular or DOM-bearing payloads

### DIFF
--- a/packages/logging/src/internal/safe-stringify.ts
+++ b/packages/logging/src/internal/safe-stringify.ts
@@ -1,0 +1,94 @@
+const UNSERIALIZABLE = '[Unserializable]';
+
+function isDOMNode(value: unknown): boolean {
+  if (typeof window === 'undefined') return false;
+  try {
+    const Element = (globalThis as any).Element;
+    const Node = (globalThis as any).Node;
+    if (typeof Element === 'function' && value instanceof Element) return true;
+    if (typeof Node === 'function' && value instanceof Node) return true;
+  } catch {
+    // instanceof against hostile globals — fall through
+  }
+  return false;
+}
+
+function domTag(value: any): string {
+  const tag = typeof value?.tagName === 'string' ? value.tagName : '';
+  if (tag) return `[Element ${tag}]`;
+  const nodeName = typeof value?.nodeName === 'string' ? value.nodeName : '';
+  return nodeName ? `[Node ${nodeName}]` : '[Node]';
+}
+
+function serializeError(err: Error, seen: WeakSet<object>): Record<string, unknown> {
+  const out: Record<string, unknown> = {
+    name: err.name,
+    message: err.message,
+    stack: err.stack,
+  };
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause !== undefined) {
+    out.cause = sanitize(cause, seen);
+  }
+  return out;
+}
+
+function sanitize(value: unknown, seen: WeakSet<object>): unknown {
+  try {
+    if (value === null || value === undefined) return value;
+
+    const t = typeof value;
+    if (t === 'function') return '[Function]';
+    if (t === 'bigint') return (value as bigint).toString();
+    if (t !== 'object') return value;
+
+    if (value instanceof Error) {
+      if (seen.has(value)) return '[Circular]';
+      seen.add(value);
+      return serializeError(value, seen);
+    }
+
+    if (isDOMNode(value)) return domTag(value);
+
+    if (seen.has(value as object)) return '[Circular]';
+    seen.add(value as object);
+
+    if (Array.isArray(value)) {
+      return value.map((v) => sanitize(v, seen));
+    }
+
+    // Keep Date / RegExp / typed arrays / etc. representable.
+    if (value instanceof Date) return value.toISOString();
+    if (value instanceof RegExp) return value.toString();
+
+    // Plain-ish object: iterate own enumerable keys.
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as object)) {
+      try {
+        out[key] = sanitize((value as Record<string, unknown>)[key], seen);
+      } catch {
+        out[key] = UNSERIALIZABLE;
+      }
+    }
+    return out;
+  } catch {
+    return UNSERIALIZABLE;
+  }
+}
+
+/**
+ * JSON.stringify that tolerates circular references, DOM nodes, functions,
+ * and Errors with `cause` chains. Never throws — falls back to a stub string
+ * for any value it cannot safely serialize.
+ */
+export function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(sanitize(value, new WeakSet()));
+  } catch {
+    try {
+      return JSON.stringify(UNSERIALIZABLE);
+    } catch {
+      return '"[Unserializable]"';
+    }
+  }
+}

--- a/packages/logging/src/transports/console.ts
+++ b/packages/logging/src/transports/console.ts
@@ -1,6 +1,7 @@
 import { Transport } from './transport';
 import { LogEvent, LogLevel, LogLevelValue } from '../logger';
 import { isBrowser } from '../runtime';
+import { safeStringify } from '../internal/safe-stringify';
 export interface ConsoleTransportConfig {
   prettyPrint?: boolean;
   logLevel?: LogLevel;
@@ -57,7 +58,7 @@ export class ConsoleTransport implements Transport {
       }
       let msg = `${ev.level} - ${ev.message}`;
       if (hasFields) {
-        msg += ' ' + JSON.stringify(ev.fields);
+        msg += ' ' + safeStringify(ev.fields);
       }
       console.log(msg);
       return;

--- a/packages/logging/src/transports/fetch.ts
+++ b/packages/logging/src/transports/fetch.ts
@@ -1,5 +1,6 @@
 import { Transport } from './transport';
 import { LogEvent, LogLevelValue, LogLevel } from '../logger';
+import { safeStringify } from '../internal/safe-stringify';
 
 interface FetchConfig {
   input: Parameters<typeof fetch>[0];
@@ -46,21 +47,34 @@ export class SimpleFetchTransport implements Transport {
       return;
     }
 
-    await fetch(this.fetchConfig.input, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      ...this.fetchConfig.init,
-      body: JSON.stringify(this.events),
-    })
-      .then(async (res) => {
-        if (!res.ok) {
-          console.error(await res.text());
-          throw new Error('Failed to flush logs');
-        }
-        this.events = [];
-      })
-      .catch(console.error);
+    const batch = this.events;
+    this.events = [];
+
+    let body: string;
+    try {
+      body = safeStringify(batch);
+    } catch (err) {
+      console.error('Failed to serialize log batch, dropping events:', err);
+      return;
+    }
+
+    try {
+      const res = await fetch(this.fetchConfig.input, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        ...this.fetchConfig.init,
+        body,
+      });
+      if (!res.ok) {
+        console.error(await res.text());
+        this.events.unshift(...batch);
+      }
+    } catch (err) {
+      console.error(err);
+      this.events.unshift(...batch);
+    }
   }
+
 }

--- a/packages/logging/test/unit/internal/safe-stringify.test.ts
+++ b/packages/logging/test/unit/internal/safe-stringify.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'vitest';
+import { safeStringify } from '../../../src/internal/safe-stringify';
+
+describe('safeStringify', () => {
+  it('round-trips a circular object without throwing', () => {
+    const a: any = { name: 'a' };
+    a.self = a;
+    const out = safeStringify(a);
+    const parsed = JSON.parse(out);
+    expect(parsed.name).toBe('a');
+    expect(parsed.self).toBe('[Circular]');
+  });
+
+  it('replaces functions with [Function]', () => {
+    const out = safeStringify({ fn: () => 1, nested: { cb: function named() {} } });
+    expect(JSON.parse(out)).toEqual({ fn: '[Function]', nested: { cb: '[Function]' } });
+  });
+
+  it('serializes Error including cause chain', () => {
+    const root = new Error('root');
+    const wrap = new Error('wrap', { cause: root });
+    const parsed = JSON.parse(safeStringify({ err: wrap }));
+    expect(parsed.err.name).toBe('Error');
+    expect(parsed.err.message).toBe('wrap');
+    expect(parsed.err.cause.message).toBe('root');
+    expect(typeof parsed.err.stack).toBe('string');
+  });
+
+  it('replaces DOM-like objects with an [Element TAG] token', () => {
+    const prevWindow = (globalThis as any).window;
+    const prevElement = (globalThis as any).Element;
+    class FakeElement {
+      tagName = 'IMG';
+    }
+    (globalThis as any).window = {};
+    (globalThis as any).Element = FakeElement;
+
+    try {
+      const el = new FakeElement();
+      const circular: any = { el };
+      (el as any).__reactFiber = { stateNode: el };
+      const parsed = JSON.parse(safeStringify({ payload: el, circular }));
+      expect(parsed.payload).toBe('[Element IMG]');
+      expect(parsed.circular.el).toBe('[Element IMG]');
+    } finally {
+      (globalThis as any).window = prevWindow;
+      (globalThis as any).Element = prevElement;
+    }
+  });
+
+  it('leaves plain objects, arrays and primitives intact', () => {
+    const input = { a: 1, b: 'x', c: [1, 2, { d: true }], e: null };
+    expect(JSON.parse(safeStringify(input))).toEqual(input);
+  });
+
+  it('handles the realistic React-fiber-on-Element shape', () => {
+    const prevWindow = (globalThis as any).window;
+    const prevElement = (globalThis as any).Element;
+    class FakeElement {
+      tagName = 'IMG';
+    }
+    (globalThis as any).window = {};
+    (globalThis as any).Element = FakeElement;
+
+    try {
+      const img: any = new FakeElement();
+      img.__reactFiber$abc = { stateNode: img };
+      const metric = {
+        name: 'LCP',
+        value: 1234,
+        entries: [{ element: img }],
+      };
+      const parsed = JSON.parse(safeStringify({ webVital: metric }));
+      expect(parsed.webVital.name).toBe('LCP');
+      expect(parsed.webVital.entries[0].element).toBe('[Element IMG]');
+    } finally {
+      (globalThis as any).window = prevWindow;
+      (globalThis as any).Element = prevElement;
+    }
+  });
+
+  it('serializes Date, RegExp, and bigint to stable primitives', () => {
+    const parsed = JSON.parse(
+      safeStringify({
+        when: new Date('2026-04-14T00:00:00.000Z'),
+        pattern: /abc/gi,
+        big: 42n,
+      }),
+    );
+    expect(parsed.when).toBe('2026-04-14T00:00:00.000Z');
+    expect(parsed.pattern).toBe('/abc/gi');
+    expect(parsed.big).toBe('42');
+  });
+
+  it('is SSR-safe: does not throw and does not tag anything as DOM when window is undefined', () => {
+    const prevWindow = (globalThis as any).window;
+    delete (globalThis as any).window;
+    try {
+      const circular: any = { a: 1 };
+      circular.self = circular;
+      const lookalike = { tagName: 'IMG', nodeType: 1 };
+      const parsed = JSON.parse(safeStringify({ circular, lookalike }));
+      expect(parsed.circular.self).toBe('[Circular]');
+      // Without window, the DOM check is skipped — lookalike stays a plain object.
+      expect(parsed.lookalike).toEqual({ tagName: 'IMG', nodeType: 1 });
+    } finally {
+      if (prevWindow === undefined) {
+        delete (globalThis as any).window;
+      } else {
+        (globalThis as any).window = prevWindow;
+      }
+    }
+  });
+
+  it('falls back to a stub when a property getter throws', () => {
+    const bad = {
+      get boom(): never {
+        throw new Error('nope');
+      },
+      ok: 1,
+    };
+    // Should not throw; should contain the [Unserializable] stub for the bad key.
+    const parsed = JSON.parse(safeStringify(bad));
+    expect(parsed.ok).toBe(1);
+    expect(parsed.boom).toBe('[Unserializable]');
+  });
+});

--- a/packages/logging/test/unit/transports/fetch.test.ts
+++ b/packages/logging/test/unit/transports/fetch.test.ts
@@ -231,6 +231,104 @@ describe('SimpleFetchTransport', () => {
     });
   });
 
+  describe('poisoned payloads', () => {
+    it('does not drop the whole batch when one event contains a circular reference', async () => {
+      let receivedLogs: any[] = [];
+      server.use(
+        http.post(API_URL, async ({ request }) => {
+          receivedLogs = (await request.json()) as any[];
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      transport = new SimpleFetchTransport({ input: API_URL });
+
+      const poisoned: any = createLogEvent(LogLevel.info, 'poisoned');
+      poisoned.fields = { self: null as any };
+      poisoned.fields.self = poisoned.fields;
+
+      transport.log([createLogEvent(LogLevel.info, 'clean-1'), poisoned, createLogEvent(LogLevel.info, 'clean-2')]);
+      await transport.flush();
+
+      expect(receivedLogs).toHaveLength(3);
+      expect(receivedLogs.map((l) => l.message)).toEqual(['clean-1', 'poisoned', 'clean-2']);
+      expect(receivedLogs[1].fields.self).toBe('[Circular]');
+    });
+
+    it('does not reject when flush body serialization hits a DOM-like node', async () => {
+      let receivedLogs: any[] = [];
+      server.use(
+        http.post(API_URL, async ({ request }) => {
+          receivedLogs = (await request.json()) as any[];
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      const prevWindow = (globalThis as any).window;
+      const prevElement = (globalThis as any).Element;
+      class FakeElement {
+        tagName = 'IMG';
+      }
+      (globalThis as any).window = {};
+      (globalThis as any).Element = FakeElement;
+
+      try {
+        transport = new SimpleFetchTransport({ input: API_URL });
+        const ev: any = createLogEvent(LogLevel.info, 'with-dom');
+        ev.fields = { webVital: { element: new FakeElement() } };
+        transport.log([ev]);
+        await transport.flush();
+        expect(receivedLogs).toHaveLength(1);
+        expect(receivedLogs[0].fields.webVital.element).toBe('[Element IMG]');
+      } finally {
+        (globalThis as any).window = prevWindow;
+        (globalThis as any).Element = prevElement;
+      }
+    });
+
+    it('requeues the batch when the server rejects the request', async () => {
+      let attempts = 0;
+      const bodies: any[] = [];
+      server.use(
+        http.post(API_URL, async ({ request }) => {
+          attempts++;
+          bodies.push(await request.json());
+          if (attempts === 1) return HttpResponse.error();
+          return HttpResponse.json({ success: true });
+        }),
+      );
+      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+      transport = new SimpleFetchTransport({ input: API_URL });
+      transport.log([createLogEvent(LogLevel.info, 'retry-me')]);
+      await transport.flush();
+      await transport.flush();
+
+      expect(attempts).toBe(2);
+      expect(bodies[1][0].message).toBe('retry-me');
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('auto-flush timer does not reject when payload is circular', async () => {
+      const unhandled = vi.fn();
+      process.on('unhandledRejection', unhandled);
+
+      server.use(http.post(API_URL, () => HttpResponse.json({ success: true })));
+
+      transport = new SimpleFetchTransport({ input: API_URL, autoFlush: { durationMs: 500 } });
+      const poisoned: any = createLogEvent(LogLevel.info, 'poisoned');
+      poisoned.fields = { self: null as any };
+      poisoned.fields.self = poisoned.fields;
+      transport.log([poisoned]);
+
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.runAllTimersAsync();
+
+      expect(unhandled).not.toHaveBeenCalled();
+      process.off('unhandledRejection', unhandled);
+    });
+  });
+
   describe('log level filtering', () => {
     it('should filter logs based on logLevel', async () => {
       let receivedLogs: any[] = [];


### PR DESCRIPTION
FetchTransport.flush serialized batches with bare JSON.stringify, which threw "Converting circular structure to JSON" whenever an event carried a value that JSON cannot represent. web-vitals metric objects (surfaced via @axiomhq/react's createWebVitalsComponent → logger.raw) expose live DOM refs on entries[] — LargestContentfulPaint.element, event-timing target, LayoutShift.sources[].node — which React 19 decorates with __reactFiber$… → stateNode back-references, closing a cycle.

Because the throw fired inside the auto-flush setTimeout callback, it surfaced as an unhandled promise rejection and the entire batched buffer was lost — one poisoned event took every queued event with it. Any consumer passing non-plain data (DOM nodes, React synthetic events, class instances with cycles) was affected.

FetchTransport and ProxyTransport now route all outbound bodies through a shared safe serializer that tolerates cycles, stubs DOM nodes as "[Element TAG]", functions as "[Function]", and walks Error.cause chains. The flush path captures the batch before awaiting fetch and wraps both serialization and the request in try/catch so the auto-flush timer can no longer reject.