### PR TITLE
fix(logging): relax axiom js peer range

### DIFF
--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -62,7 +62,7 @@
     "vite": "^7.3.2"
   },
   "peerDependencies": {
-    "@axiomhq/js": "^1.4.0"
+    "@axiomhq/js": "^1.6.0"
   },
   "peerDependenciesMeta": {
     "@axiomhq/js": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -62,7 +62,7 @@
     "vite": "^7.3.2"
   },
   "peerDependencies": {
-    "@axiomhq/js": "^1.6.0"
+    "@axiomhq/js": "^1.0.0"
   },
   "peerDependenciesMeta": {
     "@axiomhq/js": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -62,7 +62,7 @@
     "vite": "^7.3.2"
   },
   "peerDependencies": {
-    "@axiomhq/js": "workspace:*"
+    "@axiomhq/js": "^1.4.0"
   },
   "peerDependenciesMeta": {
     "@axiomhq/js": {


### PR DESCRIPTION
## Summary
- relax `@axiomhq/logging`'s optional peer dependency on `@axiomhq/js` from the workspace exact-version publish behavior to `^1.0.0`
- allow consumers to install any compatible `@axiomhq/js` 1.x release without npm peer resolution failures

## Root cause
`workspace:*` in a peer dependency is published by pnpm as an exact version, so `@axiomhq/logging@0.2.0` ended up requiring exactly `@axiomhq/js@1.4.0`.

## Compatibility
The `AxiomJSTransport` API surface used by `@axiomhq/logging` -- `Axiom`, `AxiomWithoutBatching`, `ingest`, and `flush` -- is present in `@axiomhq/js@1.0.0`, so `^1.0.0` reflects the minimum compatible 1.x API floor.

One caveat: a repro install with `@axiomhq/js@1.0.0` reports npm audit findings from that older client's transitive dependency tree. This peer range does not install `@axiomhq/js` for users, but it does allow consumers who are already pinned to older 1.x clients.

## Validation
- `pnpm --filter @axiomhq/logging lint`
- `pnpm --filter @axiomhq/js build`
- `pnpm --filter @axiomhq/logging test`
- `pnpm pack` and inspected the packed manifest
- installed the local logging tarball with `@axiomhq/js@1.0.0` using npm