### PR TITLE
fix(tanstack-start): prepare initial release

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -5,5 +5,5 @@
   "packages/logging": "0.2.0",
   "packages/react": "0.2.0",
   "packages/nextjs": "0.2.0",
-  "packages/tanstack-start": "0.1.0"
+  "packages/tanstack-start": "0.0.0"
 }

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/tanstack-start",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "The official TanStack Start package for Axiom",
   "author": "Axiom, Inc.",
   "license": "MIT",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -44,10 +44,7 @@
     },
     "packages/tanstack-start": {
       "release-type": "node",
-      "versioning-strategy": "prerelease",
-      "include-v-in-tag": false,
-      "prerelease": true,
-      "prerelease-type": "alpha"
+      "include-v-in-tag": false
     }
   }
 }


### PR DESCRIPTION
## Summary
- remove TanStack Start prerelease/alpha release-please config
- reset the unreleased TanStack Start package and manifest baseline to `0.0.0` so the generated release PR produces `0.0.1`

## Testing
- `jq empty release-please-config.json .release-please-manifest.json packages/tanstack-start/package.json`
- `git diff --check`

After this lands, release-please should regenerate the open release PR with TanStack Start as a normal `0.0.1` release.