### PR TITLE
fix(tanstack-start): set initial release version

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -44,7 +44,8 @@
     },
     "packages/tanstack-start": {
       "release-type": "node",
-      "include-v-in-tag": false
+      "include-v-in-tag": false,
+      "initial-version": "0.0.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
- set TanStack Start release-please `initial-version` to `0.0.1`
- keep the package and manifest baseline at `0.0.0` so the first generated release is `0.0.1`, not release-please's default `1.0.0`

## Testing
- `jq empty release-please-config.json`
- `git diff --check`

After this lands, release-please should update PR #424 to publish `@axiomhq/tanstack-start@0.0.1`.