### PR TITLE
fix(tanstack-start): publish releases to latest

### DIFF
--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -93,9 +93,6 @@
   "bugs": {
     "url": "https://github.com/axiomhq/axiom-js/issues"
   },
-  "publishConfig": {
-    "tag": "alpha"
-  },
   "peerDependencies": {
     "@axiomhq/logging": "workspace:*",
     "@tanstack/router-core": ">=1",


### PR DESCRIPTION
## Summary
- remove the TanStack Start package `publishConfig.tag = alpha` override
- let the shared publish workflow publish future releases with npm's default `latest` dist-tag

## Testing
- `jq empty packages/tanstack-start/package.json`
- `git diff --check`

After this lands, future release-please publishes for `@axiomhq/tanstack-start` should use `latest` unless the workflow explicitly passes another tag.