### PR TITLE
feat(tanstack-start): import middleware from start core

### DIFF
--- a/examples/tanstack-start-solid/src/start.ts
+++ b/examples/tanstack-start-solid/src/start.ts
@@ -1,4 +1,4 @@
-import { createMiddleware, createStart } from '@tanstack/solid-start'
+import { createStart } from '@tanstack/solid-start'
 import {
   createAxiomFnMiddleware,
   createAxiomRequestMiddleware,
@@ -7,10 +7,10 @@ import { startLogger } from './lib/logger'
 
 export const startInstance = createStart(() => ({
   requestMiddleware: [
-    createAxiomRequestMiddleware(createMiddleware, startLogger),
+    createAxiomRequestMiddleware(startLogger),
   ],
   functionMiddleware: [
-    createAxiomFnMiddleware(createMiddleware, startLogger, {
+    createAxiomFnMiddleware(startLogger, {
       correlation: true,
     }),
   ],

--- a/examples/tanstack-start/src/start.ts
+++ b/examples/tanstack-start/src/start.ts
@@ -1,4 +1,4 @@
-import { createMiddleware, createStart } from '@tanstack/react-start'
+import { createStart } from '@tanstack/react-start'
 import {
   createAxiomFnMiddleware,
   createAxiomRequestMiddleware,
@@ -7,10 +7,10 @@ import { startLogger } from './lib/logger'
 
 export const startInstance = createStart(() => ({
   requestMiddleware: [
-    createAxiomRequestMiddleware(createMiddleware, startLogger),
+    createAxiomRequestMiddleware(startLogger),
   ],
   functionMiddleware: [
-    createAxiomFnMiddleware(createMiddleware, startLogger, {
+    createAxiomFnMiddleware(startLogger, {
       correlation: true,
     }),
   ],

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -30,7 +30,6 @@ Use the root package for framework-neutral Start observability:
 - `tanStackStartClientFormatters`
 
 ```ts
-import { createMiddleware } from '@tanstack/react-start';
 import {
   createAxiomFnMiddleware,
   createAxiomRequestMiddleware,
@@ -88,21 +87,20 @@ export const startLogger = new Logger({
 The Start middleware APIs are framework-neutral because they build on TanStack Start core contracts.
 
 ```ts
-import { createMiddleware } from '@tanstack/react-start';
 import {
   createAxiomFnMiddleware,
   createAxiomRequestMiddleware,
 } from '@axiomhq/tanstack-start';
 
 export const requestMiddleware = [
-  createAxiomRequestMiddleware(createMiddleware, startLogger, {
+  createAxiomRequestMiddleware(startLogger, {
     include: ['/api/*', '/_server/*'],
     exclude: ['/api/health'],
   }),
 ];
 
 export const functionMiddleware = [
-  createAxiomFnMiddleware(createMiddleware, startLogger, {
+  createAxiomFnMiddleware(startLogger, {
     correlation: true,
   }),
 ];
@@ -124,7 +122,7 @@ import {
 } from '@axiomhq/tanstack-start';
 
 export const requestMiddleware = [
-  createAxiomRequestMiddleware(createMiddleware, startLogger, {
+  createAxiomRequestMiddleware(startLogger, {
     onSuccess: async (data) => {
       const [message, report] = transformStartRequestSuccessResult(data);
       const logLevel = getLogLevelFromStatusCode(data.response.status);
@@ -161,7 +159,7 @@ import {
 } from '@axiomhq/tanstack-start';
 
 export const functionMiddleware = [
-  createAxiomFnMiddleware(createMiddleware, startLogger, {
+  createAxiomFnMiddleware(startLogger, {
     correlation: true,
     onSuccess: async (data) => {
       const [message, report] = transformStartFunctionSuccessResult(data);
@@ -196,7 +194,7 @@ export const functionMiddleware = [
 For simple side effects, callbacks can ignore logging entirely:
 
 ```ts
-createAxiomRequestMiddleware(createMiddleware, startLogger, {
+createAxiomRequestMiddleware(startLogger, {
   onSuccess: async (data) => {
     await analytics.track('request_complete', {
       path: new URL(data.request.url).pathname,

--- a/packages/tanstack-start/src/start.ts
+++ b/packages/tanstack-start/src/start.ts
@@ -6,12 +6,12 @@ import {
   type LogEvent,
   type LogLevel as LogLevelType,
 } from '@axiomhq/logging';
-import type {
-  FunctionMiddlewareClientFnOptions,
-  FunctionMiddlewareServerFnOptions,
+import {
   createMiddleware,
-  RequestServerOptions,
-} from '@tanstack/start-client-core' with { 'resolution-mode': 'import' };
+  type FunctionMiddlewareClientFnOptions,
+  type FunctionMiddlewareServerFnOptions,
+  type RequestServerOptions,
+} from '@tanstack/start-client-core';
 import { frameworkIdentifierFormatter } from './identifier';
 import {
   getServerContextStore,
@@ -610,7 +610,6 @@ const defaultFunctionOnError = async (logger: Logger, data: StartFunctionErrorDa
 };
 
 export const createAxiomRequestMiddleware = (
-  createMiddleware: TanStackCreateMiddleware,
   logger: Logger,
   config: StartRequestMiddlewareConfig = {},
 ) => {
@@ -743,14 +742,12 @@ const createFunctionCorrelationClientHandler = (config: StartFunctionCorrelation
 };
 
 export const createAxiomFnCorrelationMiddleware = (
-  createMiddleware: TanStackCreateMiddleware,
   config: StartFunctionCorrelationMiddlewareConfig = {},
 ) => {
   return createMiddleware({ type: 'function' }).client(createFunctionCorrelationClientHandler(config));
 };
 
 export const createAxiomFnMiddleware = (
-  createMiddleware: TanStackCreateMiddleware,
   logger: Logger,
   config: StartFunctionMiddlewareConfig = {},
 ) => {

--- a/packages/tanstack-start/test/unit/start.test.ts
+++ b/packages/tanstack-start/test/unit/start.test.ts
@@ -1,5 +1,27 @@
 import { EVENT, LogLevel } from '@axiomhq/logging';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { createDefaultMiddlewareBuilder, mockCreateMiddleware } = vi.hoisted(() => {
+  const createDefaultMiddlewareBuilder = () => ({
+    client: (handler: unknown) => handler,
+    server: (handler: unknown) => handler,
+  });
+
+  return {
+    createDefaultMiddlewareBuilder,
+    mockCreateMiddleware: vi.fn(createDefaultMiddlewareBuilder),
+  };
+});
+
+vi.mock('@tanstack/start-client-core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/start-client-core')>();
+
+  return {
+    ...actual,
+    createMiddleware: mockCreateMiddleware,
+  };
+});
+
 import {
   captureError,
   createAxiomFnCorrelationMiddleware,
@@ -14,7 +36,6 @@ import {
   type StartFunctionContext,
   type StartRequestContext,
   type StartUncaughtErrorData,
-  type TanStackCreateMiddleware,
 } from '../../src/start';
 import { mockLogger } from '../lib/mock';
 
@@ -22,25 +43,17 @@ const waitForTurn = async () => {
   await new Promise((resolve) => setTimeout(resolve, 0));
 };
 
-const createMockCreateMiddleware = () => {
-  const createMiddleware = vi.fn(() => ({
-    client: (handler: unknown) => handler,
-    server: (handler: unknown) => handler,
-  }));
-
-  return createMiddleware as unknown as TanStackCreateMiddleware;
-};
-
 describe('start middleware', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCreateMiddleware.mockReset();
+    mockCreateMiddleware.mockImplementation(createDefaultMiddlewareBuilder);
     vi.mocked(mockLogger.flush).mockReset();
     vi.mocked(mockLogger.flush).mockImplementation(() => undefined as never);
   });
 
   it('logs request middleware success with status-aware level', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomRequestMiddleware(mockLogger) as unknown as (
       context: StartRequestContext,
     ) => Promise<unknown>;
 
@@ -89,7 +102,6 @@ describe('start middleware', () => {
   });
 
   it('awaits request flush before resolving', async () => {
-    const createMiddleware = createMockCreateMiddleware();
     let resolveFlush: (() => void) | undefined;
     const flushPromise = new Promise<void>((resolve) => {
       resolveFlush = resolve;
@@ -97,7 +109,7 @@ describe('start middleware', () => {
 
     vi.mocked(mockLogger.flush).mockImplementation(() => flushPromise as never);
 
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomRequestMiddleware(mockLogger) as unknown as (
       context: StartRequestContext,
     ) => Promise<unknown>;
 
@@ -133,8 +145,7 @@ describe('start middleware', () => {
   });
 
   it('logs request middleware error, flushes and rethrows', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomRequestMiddleware(mockLogger) as unknown as (
       context: StartRequestContext,
     ) => Promise<unknown>;
 
@@ -166,8 +177,7 @@ describe('start middleware', () => {
   });
 
   it('includes correlation id for request middleware when header is present', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomRequestMiddleware(mockLogger) as unknown as (
       context: StartRequestContext,
     ) => Promise<unknown>;
 
@@ -202,10 +212,9 @@ describe('start middleware', () => {
   });
 
   it('supports custom request callbacks', async () => {
-    const createMiddleware = createMockCreateMiddleware();
     const onSuccess = vi.fn();
 
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger, {
+    const middleware = createAxiomRequestMiddleware(mockLogger, {
       onSuccess,
     }) as unknown as (context: StartRequestContext) => Promise<unknown>;
 
@@ -235,10 +244,9 @@ describe('start middleware', () => {
   });
 
   it('supports custom request error callbacks', async () => {
-    const createMiddleware = createMockCreateMiddleware();
     const onError = vi.fn();
 
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger, {
+    const middleware = createAxiomRequestMiddleware(mockLogger, {
       onError,
     }) as unknown as (context: StartRequestContext) => Promise<unknown>;
 
@@ -268,8 +276,7 @@ describe('start middleware', () => {
   });
 
   it('logs function middleware success and omits data by default', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomFnMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomFnMiddleware(mockLogger) as unknown as (
       context: StartFunctionContext,
     ) => Promise<unknown>;
 
@@ -312,9 +319,8 @@ describe('start middleware', () => {
   });
 
   it('supports custom function success callbacks', async () => {
-    const createMiddleware = createMockCreateMiddleware();
     const onSuccess = vi.fn();
-    const middleware = createAxiomFnMiddleware(createMiddleware, mockLogger, {
+    const middleware = createAxiomFnMiddleware(mockLogger, {
       onSuccess,
     }) as unknown as (context: StartFunctionContext) => Promise<unknown>;
 
@@ -351,9 +357,8 @@ describe('start middleware', () => {
   });
 
   it('supports custom function error callbacks', async () => {
-    const createMiddleware = createMockCreateMiddleware();
     const onError = vi.fn();
-    const middleware = createAxiomFnMiddleware(createMiddleware, mockLogger, {
+    const middleware = createAxiomFnMiddleware(mockLogger, {
       onError,
     }) as unknown as (context: StartFunctionContext) => Promise<unknown>;
 
@@ -386,7 +391,6 @@ describe('start middleware', () => {
   });
 
   it('awaits function flush before resolving', async () => {
-    const createMiddleware = createMockCreateMiddleware();
     let resolveFlush: (() => void) | undefined;
     const flushPromise = new Promise<void>((resolve) => {
       resolveFlush = resolve;
@@ -394,7 +398,7 @@ describe('start middleware', () => {
 
     vi.mocked(mockLogger.flush).mockImplementation(() => flushPromise as never);
 
-    const middleware = createAxiomFnMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomFnMiddleware(mockLogger) as unknown as (
       context: StartFunctionContext,
     ) => Promise<unknown>;
 
@@ -432,8 +436,7 @@ describe('start middleware', () => {
   });
 
   it('adds correlation context and header in function client middleware', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomFnCorrelationMiddleware(createMiddleware, {
+    const middleware = createAxiomFnCorrelationMiddleware({
       createRequestId: () => 'corr-generated',
     }) as unknown as (context: StartFunctionClientContext) => Promise<unknown>;
 
@@ -471,8 +474,7 @@ describe('start middleware', () => {
   });
 
   it('reuses existing request_id in function client middleware', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomFnCorrelationMiddleware(createMiddleware) as unknown as (
+    const middleware = createAxiomFnCorrelationMiddleware() as unknown as (
       context: StartFunctionClientContext,
     ) => Promise<unknown>;
 
@@ -508,7 +510,7 @@ describe('start middleware', () => {
   });
 
   it('supports correlation through createAxiomFnMiddleware config', async () => {
-    const createMiddleware = vi.fn(() => ({
+    mockCreateMiddleware.mockImplementationOnce(() => ({
       client: (clientHandler: unknown) => ({
         server: (serverHandler: unknown) => ({
           clientHandler,
@@ -516,9 +518,9 @@ describe('start middleware', () => {
         }),
       }),
       server: (serverHandler: unknown) => serverHandler,
-    })) as unknown as TanStackCreateMiddleware;
+    }));
 
-    const middleware = createAxiomFnMiddleware(createMiddleware, mockLogger, {
+    const middleware = createAxiomFnMiddleware(mockLogger, {
       correlation: {
         createRequestId: () => 'corr-from-config',
       },
@@ -556,8 +558,7 @@ describe('start middleware', () => {
   });
 
   it('logs function middleware error, flushes and rethrows', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomFnMiddleware(createMiddleware, mockLogger) as unknown as (
+    const middleware = createAxiomFnMiddleware(mockLogger) as unknown as (
       context: StartFunctionContext,
     ) => Promise<unknown>;
 
@@ -585,8 +586,7 @@ describe('start middleware', () => {
   });
 
   it('supports include/exclude request matching', async () => {
-    const createMiddleware = createMockCreateMiddleware();
-    const middleware = createAxiomRequestMiddleware(createMiddleware, mockLogger, {
+    const middleware = createAxiomRequestMiddleware(mockLogger, {
       include: '/api/*',
       exclude: '/api/internal/*',
     }) as unknown as (context: StartRequestContext) => Promise<unknown>;


### PR DESCRIPTION
## Summary
- Import TanStack Start's createMiddleware directly from @tanstack/start-client-core inside the Axiom middleware factories
- Remove createMiddleware dependency injection from the public createAxiom*Middleware APIs
- Update unit tests, README snippets, and React/Solid TanStack Start examples for the new call signatures

## Verification
- pnpm --filter @axiomhq/tanstack-start test
- pnpm --filter @axiomhq/tanstack-start build
- pnpm --filter @axiomhq/tanstack-start lint