### PR TITLE
feat: added X-Axiom-Client attribution header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         node:
           - 20.x
           - 22.x
+          - 24.x
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -89,6 +90,7 @@ jobs:
         node:
           - 20.x
           - 22.x
+          - 24.x
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -116,6 +118,7 @@ jobs:
         node:
           - 20.x
           - 22.x
+          - 24.x
     env:
       AXIOM_TOKEN: ${{ secrets.TESTING_DEV_API_TOKEN }}
       AXIOM_URL: ${{ secrets.TESTING_DEV_API_URL }}

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -14,7 +14,7 @@ axiom.ingest('DATASET_NAME', [{ foo: 'bar' }]);
 await axiom.flush();
 ```
 
-Custom products are appended to the `Axiom-Client` header, for example `axiom-js/<version> my-app/1.0`.
+Custom products are appended to the `X-Axiom-Client` header, for example `axiom-js/<version> my-app/1.0`.
 You can also append products after creating the client with `axiom.appendAxiomClient('my-integration/1.0')`.
 
 ## Requirements

--- a/packages/js/README.md
+++ b/packages/js/README.md
@@ -7,11 +7,15 @@ import { Axiom } from '@axiomhq/js';
 
 const axiom = new Axiom({
   token: process.env.AXIOM_TOKEN,
+  axiomClient: 'my-app/1.0',
 });
 
 axiom.ingest('DATASET_NAME', [{ foo: 'bar' }]);
 await axiom.flush();
 ```
+
+Custom products are appended to the `Axiom-Client` header, for example `axiom-js/<version> my-app/1.0`.
+You can also append products after creating the client with `axiom.appendAxiomClient('my-integration/1.0')`.
 
 ## Requirements
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axiomhq/js",
   "description": "The official javascript bindings for the Axiom API",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -39,6 +39,18 @@ class BaseClient extends HTTPClient {
     }
   }
 
+  // Services create their own HTTPClient instances, so appending after construction
+  // must update the base client and each mounted service client.
+  appendAxiomClient = (axiomClient: string) => {
+    super.appendAxiomClient(axiomClient);
+    this.annotations.appendAxiomClient(axiomClient);
+    this.dashboards.appendAxiomClient(axiomClient);
+    this.datasets.appendAxiomClient(axiomClient);
+    this.monitors.appendAxiomClient(axiomClient);
+    this.savedQueries.appendAxiomClient(axiomClient);
+    this.users.appendAxiomClient(axiomClient);
+  };
+
   /**
    * Ingest events into the provided dataset using raw data types, e.g: string, buffer or a stream.
    *

--- a/packages/js/src/httpClient.ts
+++ b/packages/js/src/httpClient.ts
@@ -75,10 +75,10 @@ export interface ClientOptions {
    */
   edgeUrl?: string;
   /**
-   * Additional client product tokens to append to the Axiom-Client header.
-   * Multiple products should be separated by spaces.
+   * Additional product tokens to append to the Axiom-Client header.
+   * Use product/version tokens separated by spaces.
    *
-   * @example "my-app/1.2.3"
+   * @example "axiom-react/1.2.3 my-app/4.5.6"
    */
   axiomClient?: string;
   onError?: (error: Error) => void;

--- a/packages/js/src/httpClient.ts
+++ b/packages/js/src/httpClient.ts
@@ -2,6 +2,7 @@ import { FetchClient } from './fetchClient.js';
 
 const Version = 'AXIOM_VERSION';
 const AxiomURL = 'https://api.axiom.co';
+const AxiomClientHeader = 'Axiom-Client';
 
 /**
  * ClientOptions is used to configure the HTTPClient and provide the necessary
@@ -73,6 +74,13 @@ export interface ClientOptions {
    * @example "http://localhost:3400/ingest"
    */
   edgeUrl?: string;
+  /**
+   * Additional client product tokens to append to the Axiom-Client header.
+   * Multiple products should be separated by spaces.
+   *
+   * @example "my-app/1.2.3"
+   */
+  axiomClient?: string;
   onError?: (error: Error) => void;
 }
 
@@ -267,13 +275,13 @@ export default abstract class HTTPClient {
   protected readonly client: FetchClient;
   protected readonly clientOptions: ClientOptions;
 
-  constructor({ orgId = '', token, url, edge, edgeUrl, onError }: ClientOptions) {
+  constructor({ orgId = '', token, url, edge, edgeUrl, axiomClient, onError }: ClientOptions) {
     if (!token) {
       console.warn('Missing Axiom token');
     }
 
     // Store options for use in ingest URL resolution
-    this.clientOptions = { orgId, token, url, edge, edgeUrl, onError };
+    this.clientOptions = { orgId, token, url, edge, edgeUrl, axiomClient, onError };
 
     // For the main API client, always use url or default (never edge options)
     // edge/edgeUrl only affects ingest endpoints, not other API calls
@@ -283,10 +291,8 @@ export default abstract class HTTPClient {
       Accept: 'application/json',
       'Content-Type': 'application/json',
       Authorization: 'Bearer ' + token,
+      [AxiomClientHeader]: appendAxiomClient('axiom-js/' + Version, axiomClient),
     };
-    if (typeof window === 'undefined') {
-      headers['User-Agent'] = 'axiom-js/' + Version;
-    }
     if (orgId) {
       headers['X-Axiom-Org-Id'] = orgId;
     }
@@ -297,4 +303,32 @@ export default abstract class HTTPClient {
       timeout: 20_000,
     });
   }
+
+  appendAxiomClient(axiomClient: string) {
+    const headers = this.client.config.headers as Record<string, string>;
+    if (!headers[AxiomClientHeader]) {
+      return;
+    }
+
+    headers[AxiomClientHeader] = appendAxiomClient(headers[AxiomClientHeader], axiomClient);
+  }
+}
+
+export function appendAxiomClient(baseAxiomClient: string, axiomClient?: string): string {
+  const additionalProducts = axiomClient?.trim().split(/\s+/).filter(Boolean) ?? [];
+  if (additionalProducts.length === 0) {
+    return baseAxiomClient;
+  }
+
+  const products = baseAxiomClient.trim().split(/\s+/).filter(Boolean);
+  const productSet = new Set(products);
+
+  for (const product of additionalProducts) {
+    if (!productSet.has(product)) {
+      products.push(product);
+      productSet.add(product);
+    }
+  }
+
+  return products.join(' ');
 }

--- a/packages/js/src/httpClient.ts
+++ b/packages/js/src/httpClient.ts
@@ -2,7 +2,7 @@ import { FetchClient } from './fetchClient.js';
 
 const Version = 'AXIOM_VERSION';
 const AxiomURL = 'https://api.axiom.co';
-const AxiomClientHeader = 'Axiom-Client';
+const AxiomClientHeader = 'X-Axiom-Client';
 
 /**
  * ClientOptions is used to configure the HTTPClient and provide the necessary
@@ -75,7 +75,7 @@ export interface ClientOptions {
    */
   edgeUrl?: string;
   /**
-   * Additional product tokens to append to the Axiom-Client header.
+   * Additional product tokens to append to the X-Axiom-Client header.
    * Use product/version tokens separated by spaces.
    *
    * @example "axiom-react/1.2.3 my-app/4.5.6"

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -198,30 +198,30 @@ describe('Axiom', () => {
     expect(axiom.users).toBeTruthy();
   });
 
-  it('appends custom products to the Axiom-Client header', async () => {
+  it('appends custom products to the X-Axiom-Client header', async () => {
     const client = new AxiomWithoutBatching({ url: clientURL, token: '', axiomClient: 'my-app/1.0' });
 
     testMockedFetchCall((_: string, init: RequestInit) => {
       const headers = new Headers(init.headers);
-      expect(headers.get('Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION my-app/1.0');
+      expect(headers.get('X-Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION my-app/1.0');
       expect(headers.get('User-Agent')).toBeNull();
     }, []);
 
     await client.datasets.list();
   });
 
-  it('does not append an empty custom Axiom-Client product', async () => {
+  it('does not append an empty custom X-Axiom-Client product', async () => {
     const client = new AxiomWithoutBatching({ url: clientURL, token: '', axiomClient: '   ' });
 
     testMockedFetchCall((_: string, init: RequestInit) => {
       const headers = new Headers(init.headers);
-      expect(headers.get('Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION');
+      expect(headers.get('X-Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION');
     }, []);
 
     await client.datasets.list();
   });
 
-  it('appends Axiom-Client products after client construction', async () => {
+  it('appends X-Axiom-Client products after client construction', async () => {
     const client = new AxiomWithoutBatching({ url: clientURL, token: '' });
 
     client.appendAxiomClient('axiom-logging/1.0 axiom-react/1.0');
@@ -229,7 +229,7 @@ describe('Axiom', () => {
 
     testMockedFetchCall((_: string, init: RequestInit) => {
       const headers = new Headers(init.headers);
-      expect(headers.get('Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION axiom-logging/1.0 axiom-react/1.0');
+      expect(headers.get('X-Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION axiom-logging/1.0 axiom-react/1.0');
     }, []);
 
     await client.datasets.list();

--- a/packages/js/test/unit/client.test.ts
+++ b/packages/js/test/unit/client.test.ts
@@ -198,6 +198,43 @@ describe('Axiom', () => {
     expect(axiom.users).toBeTruthy();
   });
 
+  it('appends custom products to the Axiom-Client header', async () => {
+    const client = new AxiomWithoutBatching({ url: clientURL, token: '', axiomClient: 'my-app/1.0' });
+
+    testMockedFetchCall((_: string, init: RequestInit) => {
+      const headers = new Headers(init.headers);
+      expect(headers.get('Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION my-app/1.0');
+      expect(headers.get('User-Agent')).toBeNull();
+    }, []);
+
+    await client.datasets.list();
+  });
+
+  it('does not append an empty custom Axiom-Client product', async () => {
+    const client = new AxiomWithoutBatching({ url: clientURL, token: '', axiomClient: '   ' });
+
+    testMockedFetchCall((_: string, init: RequestInit) => {
+      const headers = new Headers(init.headers);
+      expect(headers.get('Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION');
+    }, []);
+
+    await client.datasets.list();
+  });
+
+  it('appends Axiom-Client products after client construction', async () => {
+    const client = new AxiomWithoutBatching({ url: clientURL, token: '' });
+
+    client.appendAxiomClient('axiom-logging/1.0 axiom-react/1.0');
+    client.appendAxiomClient('axiom-react/1.0');
+
+    testMockedFetchCall((_: string, init: RequestInit) => {
+      const headers = new Headers(init.headers);
+      expect(headers.get('Axiom-Client')).toEqual('axiom-js/AXIOM_VERSION axiom-logging/1.0 axiom-react/1.0');
+    }, []);
+
+    await client.datasets.list();
+  });
+
   it('Retries failed 5xx requests', async () => {
     // TODO: this doesn't actually check that retries happened, fix
     mockFetchResponse({ message: 'Internal Server Error' }, 500);

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -9,13 +9,19 @@ import { Logger, ConsoleTransport, AxiomJSTransport } from '@axiomhq/logging';
 
 export const logger = new Logger({
   transports: [
-    new AxiomJSTransport({ axiom: axiomClient, dataset: process.env.AXIOM_DATASET! }),
+    new AxiomJSTransport({
+      axiom: axiomClient,
+      dataset: process.env.AXIOM_DATASET!,
+      axiomClient: 'my-app/1.0',
+    }),
     new ConsoleTransport({ prettyPrint: true }),
   ],
 });
 
 logger.info('Hello World!');
 ```
+
+`AxiomJSTransport` appends logging package usage to the Axiom client's `Axiom-Client` header. With the example above, requests use an `Axiom-Client` header like `axiom-js/<version> axiom-logging/<version> my-app/1.0`.
 
 ## Requirements
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -21,7 +21,7 @@ export const logger = new Logger({
 logger.info('Hello World!');
 ```
 
-`AxiomJSTransport` appends logging package usage to the Axiom client's `Axiom-Client` header. With the example above, requests use an `Axiom-Client` header like `axiom-js/<version> axiom-logging/<version> my-app/1.0`.
+`AxiomJSTransport` appends logging package usage to the Axiom client's `X-Axiom-Client` header. With the example above, requests use an `X-Axiom-Client` header like `axiom-js/<version> axiom-logging/<version> my-app/1.0`.
 
 ## Requirements
 

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axiomhq/logging",
   "description": "The official logging package for Axiom",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "contributors": [

--- a/packages/logging/src/logger.ts
+++ b/packages/logging/src/logger.ts
@@ -91,6 +91,10 @@ export class Logger {
     this.config.transports.forEach((transport) => transport.log([log]));
   }
 
+  appendAxiomClient = (axiomClient: string) => {
+    this.config.transports.forEach((transport) => transport.appendAxiomClient?.(axiomClient));
+  };
+
   /**
    * Log a debug message
    * @param message The log message

--- a/packages/logging/src/transports/axiom-js.ts
+++ b/packages/logging/src/transports/axiom-js.ts
@@ -1,18 +1,32 @@
 import { Axiom, AxiomWithoutBatching } from '@axiomhq/js';
 import { LogLevel, LogLevelValue } from '../logger';
+import { Version } from '../runtime';
 import { Transport } from './transport';
 
 interface AxiomJSTransportConfig {
   axiom: Axiom | AxiomWithoutBatching;
   dataset: string;
   logLevel?: LogLevel;
+  axiomClient?: string;
 }
+
+type AxiomClientClient = {
+  appendAxiomClient?: (axiomClient: string) => void;
+};
+
+export const axiomClient = `axiom-logging/${Version ?? 'unknown'}`;
+
 export class AxiomJSTransport implements Transport {
   private config: AxiomJSTransportConfig;
   private promises: Promise<any>[] = [];
 
   constructor(config: AxiomJSTransportConfig) {
     this.config = config;
+    this.appendAxiomClient(config.axiomClient ? `${axiomClient} ${config.axiomClient}` : axiomClient);
+  }
+
+  appendAxiomClient(axiomClient: string) {
+    (this.config.axiom as AxiomClientClient).appendAxiomClient?.(axiomClient);
   }
 
   log(logs: any[]) {

--- a/packages/logging/src/transports/axiom-js.ts
+++ b/packages/logging/src/transports/axiom-js.ts
@@ -7,6 +7,12 @@ interface AxiomJSTransportConfig {
   axiom: Axiom | AxiomWithoutBatching;
   dataset: string;
   logLevel?: LogLevel;
+  /**
+   * Additional product tokens to append to the Axiom-Client header.
+   * Use product/version tokens separated by spaces.
+   *
+   * @example "axiom-react/1.2.3 my-app/4.5.6"
+   */
   axiomClient?: string;
 }
 

--- a/packages/logging/src/transports/axiom-js.ts
+++ b/packages/logging/src/transports/axiom-js.ts
@@ -8,7 +8,7 @@ interface AxiomJSTransportConfig {
   dataset: string;
   logLevel?: LogLevel;
   /**
-   * Additional product tokens to append to the Axiom-Client header.
+   * Additional product tokens to append to the X-Axiom-Client header.
    * Use product/version tokens separated by spaces.
    *
    * @example "axiom-react/1.2.3 my-app/4.5.6"

--- a/packages/logging/src/transports/transport.ts
+++ b/packages/logging/src/transports/transport.ts
@@ -1,4 +1,5 @@
 export interface Transport {
   log: (logs: any[]) => Promise<void> | void;
   flush: () => Promise<void> | void;
+  appendAxiomClient?: (axiomClient: string) => void;
 }

--- a/packages/logging/test/unit/logger.test.ts
+++ b/packages/logging/test/unit/logger.test.ts
@@ -160,6 +160,28 @@ describe('Logger', () => {
     });
   });
 
+  describe('appendAxiomClient', () => {
+    it('should forward Axiom-Client products to transports that support it', () => {
+      const appendAxiomClient = vi.fn();
+      const transport = {
+        log: vi.fn(),
+        flush: vi.fn(),
+        appendAxiomClient,
+      };
+      logger = new Logger({
+        transports: [transport],
+      });
+
+      logger.appendAxiomClient('axiom-react/1.0');
+
+      expect(appendAxiomClient).toHaveBeenCalledWith('axiom-react/1.0');
+    });
+
+    it('should ignore transports that do not support Axiom-Client products', () => {
+      expect(() => logger.appendAxiomClient('axiom-react/1.0')).not.toThrow();
+    });
+  });
+
   describe('Root fields injection using EVENT symbol', () => {
     it('should inject root fields into log events', () => {
       logger.info('user action', { [EVENT]: { userId: '123' } });

--- a/packages/logging/test/unit/logger.test.ts
+++ b/packages/logging/test/unit/logger.test.ts
@@ -161,7 +161,7 @@ describe('Logger', () => {
   });
 
   describe('appendAxiomClient', () => {
-    it('should forward Axiom-Client products to transports that support it', () => {
+    it('should forward X-Axiom-Client products to transports that support it', () => {
       const appendAxiomClient = vi.fn();
       const transport = {
         log: vi.fn(),
@@ -177,7 +177,7 @@ describe('Logger', () => {
       expect(appendAxiomClient).toHaveBeenCalledWith('axiom-react/1.0');
     });
 
-    it('should ignore transports that do not support Axiom-Client products', () => {
+    it('should ignore transports that do not support X-Axiom-Client products', () => {
       expect(() => logger.appendAxiomClient('axiom-react/1.0')).not.toThrow();
     });
   });

--- a/packages/logging/test/unit/transports/axiom-js.test.ts
+++ b/packages/logging/test/unit/transports/axiom-js.test.ts
@@ -47,11 +47,11 @@ describe('AxiomJSTransport', () => {
     });
 
     describe('appendAxiomClient', () => {
-      it('should append logging Axiom-Client product when created', () => {
+      it('should append logging X-Axiom-Client product when created', () => {
         expect((mockAxiom as any).appendAxiomClient).toHaveBeenCalledWith(axiomClient);
       });
 
-      it('should append custom Axiom-Client products after logging product', () => {
+      it('should append custom X-Axiom-Client products after logging product', () => {
         transport = new AxiomJSTransport({
           axiom: mockAxiom,
           dataset: DATASET,
@@ -61,7 +61,7 @@ describe('AxiomJSTransport', () => {
         expect((mockAxiom as any).appendAxiomClient).toHaveBeenLastCalledWith(`${axiomClient} axiom-react/0.0.0`);
       });
 
-      it('should append Axiom-Client products through the transport method', () => {
+      it('should append X-Axiom-Client products through the transport method', () => {
         transport.appendAxiomClient?.('my-app/1.0');
 
         expect((mockAxiom as any).appendAxiomClient).toHaveBeenCalledWith('my-app/1.0');

--- a/packages/logging/test/unit/transports/axiom-js.test.ts
+++ b/packages/logging/test/unit/transports/axiom-js.test.ts
@@ -1,5 +1,5 @@
 import { describe, beforeEach, it, expect, vi } from 'vitest';
-import { AxiomJSTransport } from '../../../src/transports/axiom-js';
+import { AxiomJSTransport, axiomClient } from '../../../src/transports/axiom-js';
 import { createLogEvent } from '../../lib/mock';
 import { Axiom, AxiomWithoutBatching } from '@axiomhq/js';
 import { LogLevel } from 'src/logger';
@@ -13,10 +13,12 @@ describe('AxiomJSTransport', () => {
   beforeEach(() => {
     mockAxiomWithoutBatching = Object.create(AxiomWithoutBatching.prototype, {
       ingest: { value: vi.fn() },
+      appendAxiomClient: { value: vi.fn() },
     });
     mockAxiom = Object.create(Axiom.prototype, {
       ingest: { value: vi.fn() },
       flush: { value: vi.fn().mockResolvedValue(undefined) },
+      appendAxiomClient: { value: vi.fn() },
     });
   });
 
@@ -41,6 +43,28 @@ describe('AxiomJSTransport', () => {
         await transport.flush();
 
         expect(mockAxiom.flush).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    describe('appendAxiomClient', () => {
+      it('should append logging Axiom-Client product when created', () => {
+        expect((mockAxiom as any).appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+      });
+
+      it('should append custom Axiom-Client products after logging product', () => {
+        transport = new AxiomJSTransport({
+          axiom: mockAxiom,
+          dataset: DATASET,
+          axiomClient: 'axiom-react/0.0.0',
+        });
+
+        expect((mockAxiom as any).appendAxiomClient).toHaveBeenLastCalledWith(`${axiomClient} axiom-react/0.0.0`);
+      });
+
+      it('should append Axiom-Client products through the transport method', () => {
+        transport.appendAxiomClient?.('my-app/1.0');
+
+        expect((mockAxiom as any).appendAxiomClient).toHaveBeenCalledWith('my-app/1.0');
       });
     });
   });

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -19,7 +19,7 @@ export const logger = new Logger({
 export const withAxiom = createAxiomRouteHandler(logger);
 ```
 
-Next.js helpers that receive a logger append `axiom-nextjs/<version>` to supported logging transports' `Axiom-Client` header.
+Next.js helpers that receive a logger append `axiom-nextjs/<version>` to supported logging transports' `X-Axiom-Client` header.
 
 ```ts
 // api/route.ts

--- a/packages/nextjs/README.md
+++ b/packages/nextjs/README.md
@@ -19,6 +19,8 @@ export const logger = new Logger({
 export const withAxiom = createAxiomRouteHandler(logger);
 ```
 
+Next.js helpers that receive a logger append `axiom-nextjs/<version>` to supported logging transports' `Axiom-Client` header.
+
 ```ts
 // api/route.ts
 import { withAxiom } from '@/lib/axiom/server';

--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/nextjs",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "author": "Axiom, Inc.",
   "license": "MIT",
   "description": "The official Next.js package for Axiom",

--- a/packages/nextjs/src/identifier.ts
+++ b/packages/nextjs/src/identifier.ts
@@ -1,10 +1,20 @@
-import type { Formatter, FrameworkIdentifier, LogEvent } from '@axiomhq/logging';
+import type { Formatter, FrameworkIdentifier, LogEvent, Logger } from '@axiomhq/logging';
 import { Version } from './lib/runtime';
 
 export const frameworkIdentifier = {
   name: 'next-axiom-version',
   version: Version ?? 'unknown',
 } satisfies FrameworkIdentifier;
+
+export const axiomClient = `axiom-nextjs/${Version ?? 'unknown'}`;
+
+type AxiomClientLogger = Logger & {
+  appendAxiomClient?: (axiomClient: string) => void;
+};
+
+export const appendNextJsAxiomClient = (logger: Logger) => {
+  (logger as AxiomClientLogger).appendAxiomClient?.(axiomClient);
+};
 
 export const frameworkIdentifierFormatter: Formatter<LogEvent, LogEvent> = (logEvent) => {
   return {

--- a/packages/nextjs/src/instrumentation.ts
+++ b/packages/nextjs/src/instrumentation.ts
@@ -1,5 +1,6 @@
 import { EVENT, Logger } from '@axiomhq/logging';
 import { Instrumentation } from 'next';
+import { appendNextJsAxiomClient } from './identifier';
 
 export const transformOnRequestError = (
   ...args: Parameters<Instrumentation.onRequestError>
@@ -36,8 +37,11 @@ export const transformOnRequestError = (
 };
 
 export const createOnRequestError =
-  (logger: Logger): Instrumentation.onRequestError =>
-  async (...args) => {
-    logger.error(...transformOnRequestError(...args));
-    await logger.flush();
+  (logger: Logger): Instrumentation.onRequestError => {
+    appendNextJsAxiomClient(logger);
+
+    return async (...args) => {
+      logger.error(...transformOnRequestError(...args));
+      await logger.flush();
+    };
   };

--- a/packages/nextjs/src/proxyRouteHandler.ts
+++ b/packages/nextjs/src/proxyRouteHandler.ts
@@ -1,6 +1,9 @@
 import { LogEvent, Logger } from '@axiomhq/logging';
+import { appendNextJsAxiomClient } from './identifier';
 
 export const createProxyRouteHandler = (logger: Logger) => {
+  appendNextJsAxiomClient(logger);
+
   return async <T extends Request>(req: T) => {
     try {
       const events = (await req.json()) as LogEvent[];

--- a/packages/nextjs/src/routeHandler.ts
+++ b/packages/nextjs/src/routeHandler.ts
@@ -5,6 +5,7 @@ import { getAccessFallbackHTTPStatus, isHTTPAccessFallbackError } from 'src/lib/
 import { getRedirectStatus, isRedirectError } from 'src/lib/next-redirect-errors';
 import { NextRequest, NextResponse } from 'next/server';
 import { isEdgeRuntime } from 'src/lib/runtime';
+import { appendNextJsAxiomClient } from './identifier';
 
 /**
  * If we don't use a constant + access via bracket notation, webpack will throw an error when after is not exported
@@ -173,6 +174,7 @@ export const createAxiomRouteHandler = <TRequestCreateRouteHandler = NextRequest
     onError?: (data: ErrorData) => void;
   },
 ) => {
+  appendNextJsAxiomClient(logger);
   const { store: argStore, onSuccess, onError } = config ?? {};
   const withAxiom = <TRequestRouteHandler = TRequestCreateRouteHandler>(handler: NextHandler<TRequestRouteHandler>) => {
     return async <C extends any = any>(

--- a/packages/nextjs/test/lib/mock.ts
+++ b/packages/nextjs/test/lib/mock.ts
@@ -10,6 +10,7 @@ export const mockLogger = {
   info: vi.fn(),
   warn: vi.fn(),
   with: vi.fn(),
+  appendAxiomClient: vi.fn(),
   flush: vi.fn(),
 } as unknown as Logger;
 // Mock after from next/server

--- a/packages/nextjs/test/unit/identifier.test.ts
+++ b/packages/nextjs/test/unit/identifier.test.ts
@@ -9,11 +9,11 @@ describe('identifier', () => {
     expect(frameworkIdentifier.version.length).toBeGreaterThan(0);
   });
 
-  it('exposes the nextjs Axiom-Client product', () => {
+  it('exposes the nextjs X-Axiom-Client product', () => {
     expect(axiomClient).toBe(`axiom-nextjs/${frameworkIdentifier.version}`);
   });
 
-  it('appends the nextjs Axiom-Client product to supported loggers', () => {
+  it('appends the nextjs X-Axiom-Client product to supported loggers', () => {
     const logger = {
       appendAxiomClient: vi.fn(),
     } as unknown as Logger;

--- a/packages/nextjs/test/unit/identifier.test.ts
+++ b/packages/nextjs/test/unit/identifier.test.ts
@@ -1,0 +1,42 @@
+import type { Logger } from '@axiomhq/logging';
+import { describe, expect, it, vi } from 'vitest';
+import { appendNextJsAxiomClient, axiomClient, frameworkIdentifier, frameworkIdentifierFormatter } from '../../src/identifier';
+
+describe('identifier', () => {
+  it('exposes the nextjs framework identifier', () => {
+    expect(frameworkIdentifier.name).toBe('next-axiom-version');
+    expect(typeof frameworkIdentifier.version).toBe('string');
+    expect(frameworkIdentifier.version.length).toBeGreaterThan(0);
+  });
+
+  it('exposes the nextjs Axiom-Client product', () => {
+    expect(axiomClient).toBe(`axiom-nextjs/${frameworkIdentifier.version}`);
+  });
+
+  it('appends the nextjs Axiom-Client product to supported loggers', () => {
+    const logger = {
+      appendAxiomClient: vi.fn(),
+    } as unknown as Logger;
+
+    appendNextJsAxiomClient(logger);
+
+    expect((logger as any).appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+  });
+
+  it('adds framework identifier metadata to log events', () => {
+    const event = {
+      level: 'info',
+      message: 'hello',
+      fields: {},
+      _time: new Date().toISOString(),
+      '@app': {
+        'axiom-logging-version': '0.0.0',
+      },
+      source: 'server-log',
+    };
+
+    const formatted = frameworkIdentifierFormatter(event);
+
+    expect(formatted['@app'][frameworkIdentifier.name]).toBe(frameworkIdentifier.version);
+  });
+});

--- a/packages/nextjs/test/unit/instrumentation.test.ts
+++ b/packages/nextjs/test/unit/instrumentation.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { InstrumentationOnRequestError } from 'next/dist/server/instrumentation/types';
 import { mockLogger } from '../lib/mock';
 import { EVENT } from '@axiomhq/logging';
+import { axiomClient } from '../../src/identifier';
 
 describe('instrumentation', () => {
   const mockRequest: Parameters<InstrumentationOnRequestError>[1] = {
@@ -61,6 +62,8 @@ describe('instrumentation', () => {
   describe('createOnRequestError', () => {
     it('should create handler that logs errors and flushes', async () => {
       const handler = createOnRequestError(mockLogger);
+      expect(mockLogger.appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+
       const testError = new Error('Test error');
 
       await handler(testError, mockRequest, mockContext);

--- a/packages/nextjs/test/unit/proxyRouteHandler.test.ts
+++ b/packages/nextjs/test/unit/proxyRouteHandler.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, afterAll } from 'vitest';
 import { createProxyRouteHandler } from '../../src/proxyRouteHandler';
 import { mockLogger } from '../lib/mock';
 import { NextRequest } from 'next/server';
+import { axiomClient } from '../../src/identifier';
 
 describe('createProxyRouteHandler', () => {
   afterAll(() => {
@@ -10,6 +11,8 @@ describe('createProxyRouteHandler', () => {
 
   it('should process log events successfully', async () => {
     const handler = createProxyRouteHandler(mockLogger);
+    expect(mockLogger.appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+
     const mockEvents = [
       { level: 'info', message: 'test1' },
       { level: 'error', message: 'test2' },

--- a/packages/nextjs/test/unit/routeHandler.test.ts
+++ b/packages/nextjs/test/unit/routeHandler.test.ts
@@ -10,11 +10,14 @@ import {
 import { mockLogger } from '../lib/mock';
 import { EVENT, LogLevel } from '@axiomhq/logging';
 import { forbidden, notFound, permanentRedirect, redirect, unauthorized } from 'next/navigation';
+import { axiomClient } from '../../src/identifier';
 
 describe('routeHandler', () => {
   describe('createAxiomRouteHandler', () => {
     it('should handle successful requests', async () => {
       const withAxiom = createAxiomRouteHandler(mockLogger);
+      expect(mockLogger.appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+
       const mockResponse = new NextResponse(null, { status: 200 });
       const handler = vi.fn().mockResolvedValue(mockResponse);
       const wrappedHandler = withAxiom(handler);

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -12,10 +12,13 @@ const logger = pino(
     options: {
       dataset: process.env.AXIOM_DATASET,
       token: process.env.AXIOM_TOKEN,
+      axiomClient: 'my-app/1.0',
     },
   }),
 );
 ```
+
+The transport sends an `Axiom-Client` header like `axiom-js/<version> axiom-pino/<version> my-app/1.0`.
 
 ## Requirements
 

--- a/packages/pino/README.md
+++ b/packages/pino/README.md
@@ -18,7 +18,7 @@ const logger = pino(
 );
 ```
 
-The transport sends an `Axiom-Client` header like `axiom-js/<version> axiom-pino/<version> my-app/1.0`.
+The transport sends an `X-Axiom-Client` header like `axiom-js/<version> axiom-pino/<version> my-app/1.0`.
 
 ## Requirements
 

--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/pino",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "The official Axiom transport for Pino",
   "type": "module",
   "types": "dist/esm/types/index.d.ts",

--- a/packages/pino/rollup.config.cjs.js
+++ b/packages/pino/rollup.config.cjs.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import replace from '@rollup/plugin-replace';
 
 export default [
   {
@@ -11,6 +12,12 @@ export default [
       preserveModules: true,
       entryFileNames: '[name].cjs',
     },
-    plugins: [typescript({ outDir: 'dist/cjs', declarationDir: 'dist/cjs/types' })],
+    plugins: [
+      typescript({ outDir: 'dist/cjs', declarationDir: 'dist/cjs/types' }),
+      replace({
+        preventAssignment: true,
+        AXIOM_VERSION: process.env.npm_package_version,
+      }),
+    ],
   },
 ];

--- a/packages/pino/rollup.config.js
+++ b/packages/pino/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import replace from '@rollup/plugin-replace';
 
 export default [
   {
@@ -10,6 +11,12 @@ export default [
       sourcemap: true,
       preserveModules: true,
     },
-    plugins: [typescript({ outDir: 'dist/esm', declarationDir: 'dist/esm/types' })],
+    plugins: [
+      typescript({ outDir: 'dist/esm', declarationDir: 'dist/esm/types' }),
+      replace({
+        preventAssignment: true,
+        AXIOM_VERSION: process.env.npm_package_version,
+      }),
+    ],
   },
 ];

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -18,7 +18,7 @@ export enum AxiomEventLevel {
 export interface Options extends ClientOptions {
   dataset: string;
   /**
-   * Additional product tokens to append to the Axiom-Client header.
+   * Additional product tokens to append to the X-Axiom-Client header.
    * Use product/version tokens separated by spaces.
    *
    * @example "axiom-react/1.2.3 my-app/4.5.6"

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -17,11 +17,17 @@ export enum AxiomEventLevel {
 
 export interface Options extends ClientOptions {
   dataset: string;
+  /**
+   * Additional product tokens to append to the Axiom-Client header.
+   * Use product/version tokens separated by spaces.
+   *
+   * @example "axiom-react/1.2.3 my-app/4.5.6"
+   */
   axiomClient?: string;
 }
 
 export default async function axiomTransport(options: Options) {
-  const clientOptions: ClientOptions & { axiomClient?: string } = {
+  const clientOptions: ClientOptions = {
     ...options,
     axiomClient: appendAxiomClient(AxiomClient, options.axiomClient),
   };

--- a/packages/pino/src/index.ts
+++ b/packages/pino/src/index.ts
@@ -1,5 +1,9 @@
 import build from 'pino-abstract-transport';
-import { Axiom, ClientOptions } from '@axiomhq/js';
+import { Axiom } from '@axiomhq/js';
+import type { ClientOptions } from '@axiomhq/js';
+
+const Version = 'AXIOM_VERSION';
+const AxiomClient = `axiom-pino/${Version}`;
 
 export enum AxiomEventLevel {
   Trace = 'trace',
@@ -13,10 +17,15 @@ export enum AxiomEventLevel {
 
 export interface Options extends ClientOptions {
   dataset: string;
+  axiomClient?: string;
 }
 
 export default async function axiomTransport(options: Options) {
-  const axiom = new Axiom(options);
+  const clientOptions: ClientOptions & { axiomClient?: string } = {
+    ...options,
+    axiomClient: appendAxiomClient(AxiomClient, options.axiomClient),
+  };
+  const axiom = new Axiom(clientOptions);
 
   const dataset = options.dataset;
 
@@ -65,3 +74,12 @@ export const mapLogLevel = (level: string | number) => {
 
   return AxiomEventLevel.Silent;
 };
+
+function appendAxiomClient(baseAxiomClient: string, axiomClient?: string): string {
+  const trimmedAxiomClient = axiomClient?.trim();
+  if (!trimmedAxiomClient) {
+    return baseAxiomClient;
+  }
+
+  return `${baseAxiomClient} ${trimmedAxiomClient}`;
+}

--- a/packages/pino/test/unit/create-transport.spec.ts
+++ b/packages/pino/test/unit/create-transport.spec.ts
@@ -27,7 +27,7 @@ describe('pino transport tests', () => {
     expect(t).toBeDefined();
   });
 
-  it('appends pino and custom Axiom-Client products', async () => {
+  it('appends pino and custom X-Axiom-Client products', async () => {
     await axiomTransport({
       token: process.env.AXIOM_TOKEN || '',
       dataset: process.env.AXIOM_DATASET || '',

--- a/packages/pino/test/unit/create-transport.spec.ts
+++ b/packages/pino/test/unit/create-transport.spec.ts
@@ -1,10 +1,39 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import axiomTransport from '../../src';
 
+const axiomMock = vi.hoisted(() => ({
+  options: [] as any[],
+}));
+
+vi.mock('@axiomhq/js', () => ({
+  Axiom: class {
+    constructor(options: any) {
+      axiomMock.options.push(options);
+    }
+
+    ingest = vi.fn();
+    flush = vi.fn();
+  },
+}));
+
 describe('pino transport tests', () => {
-  it('creates a truthy instance', () => {
-    const t = axiomTransport({ token: process.env.AXIOM_TOKEN || '', dataset: process.env.AXIOM_DATASET || ''});
+  beforeEach(() => {
+    axiomMock.options = [];
+  });
+
+  it('creates a truthy instance', async () => {
+    const t = await axiomTransport({ token: process.env.AXIOM_TOKEN || '', dataset: process.env.AXIOM_DATASET || '' });
     expect(t).toBeTruthy();
     expect(t).toBeDefined();
+  });
+
+  it('appends pino and custom Axiom-Client products', async () => {
+    await axiomTransport({
+      token: process.env.AXIOM_TOKEN || '',
+      dataset: process.env.AXIOM_DATASET || '',
+      axiomClient: 'my-app/1.0',
+    });
+
+    expect(axiomMock.options[0].axiomClient).toEqual('axiom-pino/AXIOM_VERSION my-app/1.0');
   });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -23,6 +23,8 @@ const WebVitals = createWebVitalsComponent(logger);
 export { useLogger, WebVitals };
 ```
 
+`createUseLogger` adds React package usage metadata to log events under `@app.react-axiom-version` and appends `axiom-react/<version>` to supported logging transports' `Axiom-Client` header.
+
 ## Requirements
 
 Node.js 20 or higher is required. Node.js 18 is no longer supported.

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -23,7 +23,7 @@ const WebVitals = createWebVitalsComponent(logger);
 export { useLogger, WebVitals };
 ```
 
-`createUseLogger` adds React package usage metadata to log events under `@app.react-axiom-version` and appends `axiom-react/<version>` to supported logging transports' `Axiom-Client` header.
+`createUseLogger` adds React package usage metadata to log events under `@app.react-axiom-version` and appends `axiom-react/<version>` to supported logging transports' `X-Axiom-Client` header.
 
 ## Requirements
 

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/react",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "The official React package for Axiom",
   "author": "Axiom, Inc.",
   "license": "MIT",

--- a/packages/react/src/identifier.ts
+++ b/packages/react/src/identifier.ts
@@ -1,0 +1,19 @@
+import type { Formatter, FrameworkIdentifier, LogEvent } from '@axiomhq/logging';
+import { Version } from './lib/runtime';
+
+export const frameworkIdentifier = {
+  name: 'react-axiom-version',
+  version: Version ?? 'unknown',
+} satisfies FrameworkIdentifier;
+
+export const axiomClient = `axiom-react/${Version ?? 'unknown'}`;
+
+export const frameworkIdentifierFormatter: Formatter<LogEvent, LogEvent> = (logEvent) => {
+  return {
+    ...logEvent,
+    '@app': {
+      ...logEvent['@app'],
+      [frameworkIdentifier.name]: frameworkIdentifier.version,
+    },
+  };
+};

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,2 +1,3 @@
+export * from './identifier';
 export * from './use-logger';
 export * from './web-vitals';

--- a/packages/react/src/lib/runtime.ts
+++ b/packages/react/src/lib/runtime.ts
@@ -1,0 +1,5 @@
+export const Version = __PACKAGE_VERSION__;
+
+declare global {
+  const __PACKAGE_VERSION__: string;
+}

--- a/packages/react/src/use-logger.ts
+++ b/packages/react/src/use-logger.ts
@@ -1,11 +1,21 @@
 'use client';
 import { Logger } from '@axiomhq/logging';
 import { useEffect, useState } from 'react';
+import { axiomClient, frameworkIdentifierFormatter } from './identifier';
+
+type AxiomClientLogger = Logger & {
+  appendAxiomClient?: (axiomClient: string) => void;
+};
 
 export function createUseLogger(logger: Logger) {
   if (!logger) {
     throw new Error('A logger must be provided to create useLogger');
   }
+
+  if (logger.config && !logger.config.formatters?.includes(frameworkIdentifierFormatter)) {
+    logger.config.formatters = [...(logger.config.formatters ?? []), frameworkIdentifierFormatter];
+  }
+  (logger as AxiomClientLogger).appendAxiomClient?.(axiomClient);
 
   const useLogger = () => {
     const [path, setPath] = useState(typeof window !== 'undefined' ? window.location.pathname : '');

--- a/packages/react/test/unit/identifier.test.ts
+++ b/packages/react/test/unit/identifier.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { frameworkIdentifier, frameworkIdentifierFormatter } from '../../src/identifier';
+import type { LogEvent } from '@axiomhq/logging';
+
+describe('identifier', () => {
+  it('exposes the react framework identifier', () => {
+    expect(frameworkIdentifier.name).toBe('react-axiom-version');
+    expect(typeof frameworkIdentifier.version).toBe('string');
+    expect(frameworkIdentifier.version.length).toBeGreaterThan(0);
+  });
+
+  it('adds framework identifier without dropping existing app metadata', () => {
+    const logEvent = {
+      level: 'info',
+      message: 'hello',
+      fields: {},
+      _time: new Date().toISOString(),
+      '@app': {
+        'axiom-logging-version': '0.0.0',
+      },
+      source: 'browser-log',
+    } as LogEvent;
+
+    const formatted = frameworkIdentifierFormatter(logEvent);
+
+    expect(formatted['@app']['axiom-logging-version']).toBe('0.0.0');
+    expect(formatted['@app'][frameworkIdentifier.name]).toBe(frameworkIdentifier.version);
+  });
+});

--- a/packages/react/test/unit/use-logger.test.ts
+++ b/packages/react/test/unit/use-logger.test.ts
@@ -1,7 +1,8 @@
 import { renderHook, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createUseLogger } from '../../src/use-logger';
-import { Logger } from '@axiomhq/logging';
+import { Logger, type Formatter, type Transport } from '@axiomhq/logging';
+import { axiomClient, frameworkIdentifier, frameworkIdentifierFormatter } from '../../src/identifier';
 
 describe('Logger hook', () => {
   let mockLogger: Logger;
@@ -44,6 +45,66 @@ describe('Logger hook', () => {
       } as unknown as Logger;
 
       expect(() => createUseLogger(mockLogger)).not.toThrow();
+    });
+
+    it('should append react Axiom-Client product through the logger', () => {
+      const appendAxiomClient = vi.fn();
+      const mockLogger = {
+        flush: () => Promise.resolve(),
+        appendAxiomClient,
+      } as unknown as Logger;
+
+      createUseLogger(mockLogger);
+
+      expect(appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+    });
+
+    it('should add the react framework identifier formatter to the logger', () => {
+      const logger = new Logger({
+        transports: [{ log: vi.fn(), flush: vi.fn() } as unknown as Transport],
+      });
+
+      createUseLogger(logger);
+      createUseLogger(logger);
+
+      expect(logger.config.formatters?.filter((formatter) => formatter === frameworkIdentifierFormatter)).toHaveLength(1);
+    });
+
+    it('should add the react framework identifier to log events', () => {
+      const logs: any[] = [];
+      const logger = new Logger({
+        transports: [
+          {
+            log: (events: any[]) => logs.push(...events),
+            flush: vi.fn(),
+          } as unknown as Transport,
+        ],
+      });
+
+      createUseLogger(logger);
+      logger.info('hello');
+
+      expect(logs[0]['@app'][frameworkIdentifier.name]).toBe(frameworkIdentifier.version);
+    });
+
+    it('should preserve existing logger formatters', () => {
+      const formatter: Formatter = (logEvent) => ({ ...logEvent, existing: true });
+      const logs: any[] = [];
+      const logger = new Logger({
+        transports: [
+          {
+            log: (events: any[]) => logs.push(...events),
+            flush: vi.fn(),
+          } as unknown as Transport,
+        ],
+        formatters: [formatter],
+      });
+
+      createUseLogger(logger);
+      logger.info('hello');
+
+      expect(logs[0].existing).toBe(true);
+      expect(logs[0]['@app'][frameworkIdentifier.name]).toBe(frameworkIdentifier.version);
     });
   });
 

--- a/packages/react/test/unit/use-logger.test.ts
+++ b/packages/react/test/unit/use-logger.test.ts
@@ -47,7 +47,7 @@ describe('Logger hook', () => {
       expect(() => createUseLogger(mockLogger)).not.toThrow();
     });
 
-    it('should append react Axiom-Client product through the logger', () => {
+    it('should append react X-Axiom-Client product through the logger', () => {
       const appendAxiomClient = vi.fn();
       const mockLogger = {
         flush: () => Promise.resolve(),

--- a/packages/react/vite.config.ts
+++ b/packages/react/vite.config.ts
@@ -2,7 +2,9 @@ import { defineConfig, mergeConfig } from 'vite';
 import { tanstackViteConfig } from '@tanstack/config/vite';
 
 const config = defineConfig({
-  // Framework plugins, vitest config, etc.
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
 });
 
 export default mergeConfig(

--- a/packages/react/vitest.config.ts
+++ b/packages/react/vitest.config.ts
@@ -3,6 +3,9 @@ import react from '@vitejs/plugin-react';
 
 export default defineConfig({
   plugins: [react()],
+  define: {
+    __PACKAGE_VERSION__: JSON.stringify(process.env.npm_package_version),
+  },
   test: {
     globals: true,
     environment: 'happy-dom',

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -82,7 +82,7 @@ export const startLogger = new Logger({
 });
 ```
 
-TanStack Start helpers that receive a logger append `axiom-tanstack-start/<version>` to supported logging transports' `Axiom-Client` header.
+TanStack Start helpers that receive a logger append `axiom-tanstack-start/<version>` to supported logging transports' `X-Axiom-Client` header.
 
 ## Shared Start Middleware
 

--- a/packages/tanstack-start/README.md
+++ b/packages/tanstack-start/README.md
@@ -82,6 +82,8 @@ export const startLogger = new Logger({
 });
 ```
 
+TanStack Start helpers that receive a logger append `axiom-tanstack-start/<version>` to supported logging transports' `Axiom-Client` header.
+
 ## Shared Start Middleware
 
 The Start middleware APIs are framework-neutral because they build on TanStack Start core contracts.

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@axiomhq/tanstack-start",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "The official TanStack Start package for Axiom",
   "author": "Axiom, Inc.",
   "license": "MIT",

--- a/packages/tanstack-start/src/identifier.ts
+++ b/packages/tanstack-start/src/identifier.ts
@@ -1,10 +1,20 @@
-import type { Formatter, FrameworkIdentifier, LogEvent } from '@axiomhq/logging';
+import type { Formatter, FrameworkIdentifier, LogEvent, Logger } from '@axiomhq/logging';
 import { Version } from './lib/runtime';
 
 export const frameworkIdentifier = {
   name: 'tanstack-start-axiom-version',
   version: Version ?? 'unknown',
 } satisfies FrameworkIdentifier;
+
+export const axiomClient = `axiom-tanstack-start/${Version ?? 'unknown'}`;
+
+type AxiomClientLogger = Logger & {
+  appendAxiomClient?: (axiomClient: string) => void;
+};
+
+export const appendTanStackStartAxiomClient = (logger: Logger) => {
+  (logger as AxiomClientLogger).appendAxiomClient?.(axiomClient);
+};
 
 export const frameworkIdentifierFormatter: Formatter<LogEvent, LogEvent> = (logEvent) => {
   return {

--- a/packages/tanstack-start/src/react.ts
+++ b/packages/tanstack-start/src/react.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@axiomhq/logging';
 import type { ErrorInfo } from 'react';
 import { reportClientError, type ClientErrorCaptureConfig } from './client';
+import { appendTanStackStartAxiomClient } from './identifier';
 
 const REACT_ERROR_SOURCE = 'tanstack-start-react-error-boundary';
 
@@ -16,6 +17,7 @@ export const createAxiomReactErrorHandler = (
   logger: Logger,
   config: ReactErrorCaptureConfig = {},
 ) => {
+  appendTanStackStartAxiomClient(logger);
   const { source = REACT_ERROR_SOURCE, ...rest } = config;
 
   return (error: unknown, errorInfo?: Pick<ErrorInfo, 'componentStack'> | ReactErrorContext) => {

--- a/packages/tanstack-start/src/router.ts
+++ b/packages/tanstack-start/src/router.ts
@@ -1,6 +1,6 @@
 import { EVENT, Logger, type Formatter } from '@axiomhq/logging';
 import type { AnyRouter, RouterEvent, RouterEvents } from '@tanstack/router-core';
-import { frameworkIdentifierFormatter } from './identifier';
+import { appendTanStackStartAxiomClient, frameworkIdentifierFormatter } from './identifier';
 
 const ROUTER_SOURCE = 'tanstack-router';
 const DEFAULT_EVENT: keyof RouterEvents = 'onResolved';
@@ -295,6 +295,8 @@ const observeRouter = (router: RouterLike, logger: Logger, options: RouterObserv
 };
 
 export const observeTanStackRouter = (logger: Logger, options: RouterObserverOptions = {}) => {
+  appendTanStackStartAxiomClient(logger);
+
   return (router: RouterLike) => {
     if (typeof window === 'undefined') {
       return () => {};

--- a/packages/tanstack-start/src/solid.ts
+++ b/packages/tanstack-start/src/solid.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@axiomhq/logging';
 import { reportClientError, type ClientErrorCaptureConfig } from './client';
+import { appendTanStackStartAxiomClient } from './identifier';
 
 const SOLID_ERROR_SOURCE = 'tanstack-start-solid-error-boundary';
 
@@ -11,6 +12,7 @@ export const createAxiomSolidErrorHandler = (
   logger: Logger,
   config: SolidErrorCaptureConfig = {},
 ) => {
+  appendTanStackStartAxiomClient(logger);
   const { source = SOLID_ERROR_SOURCE, ...rest } = config;
 
   return (error: unknown, _reset?: () => void) => {

--- a/packages/tanstack-start/src/start.ts
+++ b/packages/tanstack-start/src/start.ts
@@ -12,7 +12,7 @@ import {
   type FunctionMiddlewareServerFnOptions,
   type RequestServerOptions,
 } from '@tanstack/start-client-core';
-import { frameworkIdentifierFormatter } from './identifier';
+import { appendTanStackStartAxiomClient, frameworkIdentifierFormatter } from './identifier';
 import {
   getServerContextStore,
   runWithServerContext,
@@ -525,6 +525,7 @@ const defaultUncaughtOnError = async (logger: Logger, data: StartUncaughtErrorDa
 };
 
 export const createAxiomUncaughtErrorHandler = (logger: Logger, config: StartUncaughtErrorCaptureConfig = {}) => {
+  appendTanStackStartAxiomClient(logger);
   const { onError, source = START_UNCAUGHT_SOURCE } = config;
 
   return async (data: StartUncaughtErrorData) => {
@@ -613,6 +614,7 @@ export const createAxiomRequestMiddleware = (
   logger: Logger,
   config: StartRequestMiddlewareConfig = {},
 ) => {
+  appendTanStackStartAxiomClient(logger);
   const { store, onSuccess, onError } = config;
 
   return createMiddleware({ type: 'request' }).server(async (requestContext: StartRequestContext) => {
@@ -678,6 +680,7 @@ const isLogEventArray = (value: unknown): value is LogEvent[] => {
 };
 
 export const createAxiomProxyHandler = (logger: Logger, config: StartProxyHandlerConfig = {}) => {
+  appendTanStackStartAxiomClient(logger);
   const { onSuccess, onError } = config;
 
   return async (request: Request) => {
@@ -751,6 +754,7 @@ export const createAxiomFnMiddleware = (
   logger: Logger,
   config: StartFunctionMiddlewareConfig = {},
 ) => {
+  appendTanStackStartAxiomClient(logger);
   const { correlation = false, store, onSuccess, onError } = config;
   const correlationConfig = correlation === true ? {} : correlation || undefined;
 

--- a/packages/tanstack-start/test/lib/mock.ts
+++ b/packages/tanstack-start/test/lib/mock.ts
@@ -9,5 +9,6 @@ export const mockLogger = {
   info: vi.fn(),
   warn: vi.fn(),
   with: vi.fn(),
+  appendAxiomClient: vi.fn(),
   flush: vi.fn(),
 } as unknown as Logger;

--- a/packages/tanstack-start/test/unit/adapters.test.ts
+++ b/packages/tanstack-start/test/unit/adapters.test.ts
@@ -2,6 +2,7 @@ import { EVENT } from '@axiomhq/logging';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createAxiomReactErrorHandler } from '../../src/react';
 import { createAxiomSolidErrorHandler } from '../../src/solid';
+import { axiomClient } from '../../src/identifier';
 import { mockLogger } from '../lib/mock';
 
 describe('framework adapters', () => {
@@ -11,6 +12,8 @@ describe('framework adapters', () => {
 
   it('logs React error-boundary errors through the React adapter', () => {
     const handleError = createAxiomReactErrorHandler(mockLogger);
+
+    expect(mockLogger.appendAxiomClient).toHaveBeenCalledWith(axiomClient);
 
     handleError(new Error('react boom'), {
       componentStack: '\n    in Widget',
@@ -53,6 +56,8 @@ describe('framework adapters', () => {
 
   it('logs Solid error-boundary errors through the Solid adapter', () => {
     const handleError = createAxiomSolidErrorHandler(mockLogger);
+
+    expect(mockLogger.appendAxiomClient).toHaveBeenCalledWith(axiomClient);
 
     handleError(new Error('solid boom'));
 

--- a/packages/tanstack-start/test/unit/identifier.test.ts
+++ b/packages/tanstack-start/test/unit/identifier.test.ts
@@ -1,11 +1,31 @@
-import { describe, expect, it } from 'vitest';
-import { frameworkIdentifier, frameworkIdentifierFormatter } from '../../src/identifier';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  appendTanStackStartAxiomClient,
+  axiomClient,
+  frameworkIdentifier,
+  frameworkIdentifierFormatter,
+} from '../../src/identifier';
+import type { Logger } from '@axiomhq/logging';
 
 describe('identifier', () => {
   it('exposes the tanstack framework identifier', () => {
     expect(frameworkIdentifier.name).toBe('tanstack-start-axiom-version');
     expect(typeof frameworkIdentifier.version).toBe('string');
     expect(frameworkIdentifier.version.length).toBeGreaterThan(0);
+  });
+
+  it('exposes the tanstack Axiom-Client product', () => {
+    expect(axiomClient).toBe(`axiom-tanstack-start/${frameworkIdentifier.version}`);
+  });
+
+  it('appends the tanstack Axiom-Client product to supported loggers', () => {
+    const logger = {
+      appendAxiomClient: vi.fn(),
+    } as unknown as Logger;
+
+    appendTanStackStartAxiomClient(logger);
+
+    expect((logger as any).appendAxiomClient).toHaveBeenCalledWith(axiomClient);
   });
 
   it('adds framework identifier without dropping existing app metadata', () => {

--- a/packages/tanstack-start/test/unit/identifier.test.ts
+++ b/packages/tanstack-start/test/unit/identifier.test.ts
@@ -14,11 +14,11 @@ describe('identifier', () => {
     expect(frameworkIdentifier.version.length).toBeGreaterThan(0);
   });
 
-  it('exposes the tanstack Axiom-Client product', () => {
+  it('exposes the tanstack X-Axiom-Client product', () => {
     expect(axiomClient).toBe(`axiom-tanstack-start/${frameworkIdentifier.version}`);
   });
 
-  it('appends the tanstack Axiom-Client product to supported loggers', () => {
+  it('appends the tanstack X-Axiom-Client product to supported loggers', () => {
     const logger = {
       appendAxiomClient: vi.fn(),
     } as unknown as Logger;

--- a/packages/tanstack-start/test/unit/router.test.ts
+++ b/packages/tanstack-start/test/unit/router.test.ts
@@ -8,6 +8,7 @@ import {
   transformRouterPerformanceResult,
   type RouterLike,
 } from '../../src/router';
+import { axiomClient } from '../../src/identifier';
 import { mockLogger } from '../lib/mock';
 
 type RouterEventType = keyof RouterEvents;
@@ -127,6 +128,8 @@ describe('router observers', () => {
     const { router, emit } = createMockRouter('/first');
 
     const observe = observeTanStackRouter(mockLogger);
+    expect(mockLogger.appendAxiomClient).toHaveBeenCalledWith(axiomClient);
+
     const unsubscribe = observe(router);
 
     emit('onResolved', '/second');

--- a/packages/winston/README.md
+++ b/packages/winston/README.md
@@ -14,6 +14,7 @@ const logger = winston.createLogger({
         new AxiomTransport({
             dataset: 'my-dataset',
             token: 'my-token',
+            axiomClient: 'my-app/1.0',
         }),
     ],
 });
@@ -23,6 +24,8 @@ logger.log({
     message: 'Logger successfully setup',
 });
 ```
+
+The transport sends an `Axiom-Client` header like `axiom-js/<version> axiom-winston/<version> my-app/1.0`.
 
 ## Requirements
 

--- a/packages/winston/README.md
+++ b/packages/winston/README.md
@@ -25,7 +25,7 @@ logger.log({
 });
 ```
 
-The transport sends an `Axiom-Client` header like `axiom-js/<version> axiom-winston/<version> my-app/1.0`.
+The transport sends an `X-Axiom-Client` header like `axiom-js/<version> axiom-winston/<version> my-app/1.0`.
 
 ## Requirements
 

--- a/packages/winston/package.json
+++ b/packages/winston/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@axiomhq/winston",
   "description": "The official Axiom transport for winston logger",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "types": "dist/esm/types/index.d.ts",
   "module": "dist/esm/index.js",

--- a/packages/winston/rollup.config.cjs.js
+++ b/packages/winston/rollup.config.cjs.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import replace from '@rollup/plugin-replace';
 
 export default [
   {
@@ -11,6 +12,12 @@ export default [
       preserveModules: true,
       entryFileNames: '[name].cjs',
     },
-    plugins: [typescript({ outDir: 'dist/cjs', declarationDir: 'dist/cjs/types' })],
+    plugins: [
+      typescript({ outDir: 'dist/cjs', declarationDir: 'dist/cjs/types' }),
+      replace({
+        preventAssignment: true,
+        AXIOM_VERSION: process.env.npm_package_version,
+      }),
+    ],
   },
 ];

--- a/packages/winston/rollup.config.js
+++ b/packages/winston/rollup.config.js
@@ -1,4 +1,5 @@
 import typescript from '@rollup/plugin-typescript';
+import replace from '@rollup/plugin-replace';
 
 export default [
   {
@@ -10,6 +11,12 @@ export default [
       sourcemap: true,
       preserveModules: true,
     },
-    plugins: [typescript({ outDir: 'dist/esm', declarationDir: 'dist/esm/types' })],
+    plugins: [
+      typescript({ outDir: 'dist/esm', declarationDir: 'dist/esm/types' }),
+      replace({
+        preventAssignment: true,
+        AXIOM_VERSION: process.env.npm_package_version,
+      }),
+    ],
   },
 ];

--- a/packages/winston/src/index.ts
+++ b/packages/winston/src/index.ts
@@ -27,7 +27,7 @@ export interface WinstonOptions extends TransportStreamOptions {
    */
   edgeUrl?: string;
   /**
-   * Additional product tokens to append to the Axiom-Client header.
+   * Additional product tokens to append to the X-Axiom-Client header.
    * Use product/version tokens separated by spaces.
    *
    * @example "axiom-react/1.2.3 my-app/4.5.6"

--- a/packages/winston/src/index.ts
+++ b/packages/winston/src/index.ts
@@ -27,10 +27,10 @@ export interface WinstonOptions extends TransportStreamOptions {
    */
   edgeUrl?: string;
   /**
-   * Additional client product tokens to append to the Axiom-Client header.
-   * Multiple products should be separated by spaces.
+   * Additional product tokens to append to the Axiom-Client header.
+   * Use product/version tokens separated by spaces.
    *
-   * @example "my-app/1.2.3"
+   * @example "axiom-react/1.2.3 my-app/4.5.6"
    */
   axiomClient?: string;
   onError?: (err: Error) => void;
@@ -45,7 +45,7 @@ export class WinstonTransport extends Transport {
 
   constructor(opts: WinstonOptions) {
     super(opts);
-    const clientOptions: ClientOptions & { axiomClient?: string } = {
+    const clientOptions: ClientOptions = {
       token: opts.token,
       orgId: opts.orgId,
       url: opts.url,

--- a/packages/winston/src/index.ts
+++ b/packages/winston/src/index.ts
@@ -6,9 +6,34 @@ import type { ClientOptions } from '@axiomhq/js';
 const Version = 'AXIOM_VERSION';
 const AxiomClient = `axiom-winston/${Version}`;
 
-export interface WinstonOptions extends TransportStreamOptions, ClientOptions {
+export interface WinstonOptions extends TransportStreamOptions {
   dataset?: string;
+  token: string;
+  orgId?: string;
+  url?: string;
+  /**
+   * The Axiom edge domain for ingestion.
+   * Specify just the domain without scheme (https:// is added automatically).
+   *
+   * @example "eu-central-1.aws.edge.axiom.co"
+   */
+  edge?: string;
+  /**
+   * The Axiom edge URL for ingestion.
+   * Specify the full URL with scheme.
+   * Takes precedence over `edge` if both are set.
+   *
+   * @example "https://eu-central-1.aws.edge.axiom.co"
+   */
+  edgeUrl?: string;
+  /**
+   * Additional client product tokens to append to the Axiom-Client header.
+   * Multiple products should be separated by spaces.
+   *
+   * @example "my-app/1.2.3"
+   */
   axiomClient?: string;
+  onError?: (err: Error) => void;
 }
 
 export class WinstonTransport extends Transport {

--- a/packages/winston/src/index.ts
+++ b/packages/winston/src/index.ts
@@ -1,28 +1,14 @@
 import Transport, { TransportStreamOptions } from 'winston-transport';
 
 import { AxiomWithoutBatching } from '@axiomhq/js';
+import type { ClientOptions } from '@axiomhq/js';
 
-export interface WinstonOptions extends TransportStreamOptions {
+const Version = 'AXIOM_VERSION';
+const AxiomClient = `axiom-winston/${Version}`;
+
+export interface WinstonOptions extends TransportStreamOptions, ClientOptions {
   dataset?: string;
-  token: string;
-  orgId?: string;
-  url?: string;
-  /**
-   * The Axiom edge domain for ingestion.
-   * Specify just the domain without scheme (https:// is added automatically).
-   *
-   * @example "eu-central-1.aws.edge.axiom.co"
-   */
-  edge?: string;
-  /**
-   * The Axiom edge URL for ingestion.
-   * Specify the full URL with scheme.
-   * Takes precedence over `edge` if both are set.
-   *
-   * @example "https://eu-central-1.aws.edge.axiom.co"
-   */
-  edgeUrl?: string;
-  onError?: (err: Error) => void;
+  axiomClient?: string;
 }
 
 export class WinstonTransport extends Transport {
@@ -34,14 +20,16 @@ export class WinstonTransport extends Transport {
 
   constructor(opts: WinstonOptions) {
     super(opts);
-    this.client = new AxiomWithoutBatching({
+    const clientOptions: ClientOptions & { axiomClient?: string } = {
       token: opts.token,
       orgId: opts.orgId,
       url: opts.url,
       edge: opts.edge,
       edgeUrl: opts.edgeUrl,
+      axiomClient: appendAxiomClient(AxiomClient, opts.axiomClient),
       onError: opts.onError,
-    });
+    };
+    this.client = new AxiomWithoutBatching(clientOptions);
     this.dataset = opts?.dataset || process.env.AXIOM_DATASET || '';
   }
 
@@ -89,4 +77,13 @@ export class WinstonTransport extends Transport {
       .then((_res: any) => callback(null))
       .catch(callback);
   }
+}
+
+function appendAxiomClient(baseAxiomClient: string, axiomClient?: string): string {
+  const trimmedAxiomClient = axiomClient?.trim();
+  if (!trimmedAxiomClient) {
+    return baseAxiomClient;
+  }
+
+  return `${baseAxiomClient} ${trimmedAxiomClient}`;
 }

--- a/packages/winston/test/unit/create-transport.spec.ts
+++ b/packages/winston/test/unit/create-transport.spec.ts
@@ -1,10 +1,32 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { WinstonTransport } from '../../src';
 
+const axiomMock = vi.hoisted(() => ({
+  options: [] as any[],
+}));
+
+vi.mock('@axiomhq/js', () => ({
+  AxiomWithoutBatching: class {
+    constructor(options: any) {
+      axiomMock.options.push(options);
+    }
+  },
+}));
+
 describe('winston transport tests', () => {
-    it('creates a truthy instance', () => {
-        const t = new WinstonTransport({ token: process.env.AXIOM_TOKEN || '' });
-        expect(t).toBeTruthy()
-        expect(t).toBeDefined()
-    })
-})
+  beforeEach(() => {
+    axiomMock.options = [];
+  });
+
+  it('creates a truthy instance', () => {
+    const t = new WinstonTransport({ token: process.env.AXIOM_TOKEN || '' });
+    expect(t).toBeTruthy();
+    expect(t).toBeDefined();
+  });
+
+  it('appends winston and custom Axiom-Client products', () => {
+    new WinstonTransport({ token: process.env.AXIOM_TOKEN || '', axiomClient: 'my-app/1.0' });
+
+    expect(axiomMock.options[0].axiomClient).toEqual('axiom-winston/AXIOM_VERSION my-app/1.0');
+  });
+});

--- a/packages/winston/test/unit/create-transport.spec.ts
+++ b/packages/winston/test/unit/create-transport.spec.ts
@@ -24,7 +24,7 @@ describe('winston transport tests', () => {
     expect(t).toBeDefined();
   });
 
-  it('appends winston and custom Axiom-Client products', () => {
+  it('appends winston and custom X-Axiom-Client products', () => {
     new WinstonTransport({ token: process.env.AXIOM_TOKEN || '', axiomClient: 'my-app/1.0' });
 
     expect(axiomMock.options[0].axiomClient).toEqual('axiom-winston/AXIOM_VERSION my-app/1.0');


### PR DESCRIPTION
## Summary

- Add a browser-safe `X-Axiom-Client` header in `@axiomhq/js` for SDK and integration attribution.
- Thread `X-Axiom-Client` product tokens through logging, Pino, Winston, React, Next.js, and TanStack Start integrations.
- Keep integration metadata on log events for React/Next/TanStack and bump patch versions for changed packages.

## Why pivot away from User-Agent

The original approach tried to append integration identifiers such as `axiom-logging/<version>` and `axiom-react/<version>` to the HTTP `User-Agent` header. That works in server runtimes, but browsers treat `User-Agent` as a forbidden request header, so browser-first packages like `@axiomhq/react` cannot reliably set it.

Using a first-party `X-Axiom-Client` header gives us one consistent attribution mechanism across Node, edge, and browser runtimes. The header carries the same product-token style value, for example:

```
X-Axiom-Client: axiom-js/<version> axiom-logging/<version> axiom-react/<version>
```

This avoids relying on forbidden browser headers while still letting Axiom capture SDK and integration usage from request metadata.

## Package impact

- `@axiomhq/js`: sets `X-Axiom-Client`, supports `axiomClient` options, and exposes `appendAxiomClient()`.
- `@axiomhq/logging`: appends `axiom-logging/<version>` through `AxiomJSTransport`.
- `@axiomhq/pino` / `@axiomhq/winston`: append their integration products and accept `axiomClient`.
- `@axiomhq/react`: appends `axiom-react/<version>` through supported logging transports and keeps `@app.react-axiom-version` event metadata.
- `@axiomhq/nextjs`: appends `axiom-nextjs/<version>` from logger-based helpers.
- `@axiomhq/tanstack-start`: appends `axiom-tanstack-start/<version>` from logger-based helpers.

## Validation

- `pnpm --filter @axiomhq/js exec vitest run test/unit/client.test.ts -t "X-Axiom-Client"`
- `pnpm --filter @axiomhq/js build && pnpm --filter @axiomhq/js build:cjs`
- `pnpm --filter @axiomhq/logging exec vitest run test/unit/logger.test.ts test/unit/transports/axiom-js.test.ts`
- `pnpm --filter @axiomhq/logging typecheck && pnpm --filter @axiomhq/logging build`
- `pnpm --filter @axiomhq/react exec vitest run test/unit/use-logger.test.ts test/unit/identifier.test.ts`
- `pnpm --filter @axiomhq/react typecheck && pnpm --filter @axiomhq/react build`
- `pnpm --filter @axiomhq/nextjs test && pnpm --filter @axiomhq/nextjs typecheck && pnpm --filter @axiomhq/nextjs build`
- `pnpm --filter @axiomhq/tanstack-start test && pnpm --filter @axiomhq/tanstack-start typecheck && pnpm --filter @axiomhq/tanstack-start build`
- `pnpm --filter @axiomhq/pino test -- --runInBand && pnpm --filter @axiomhq/pino typecheck && pnpm --filter @axiomhq/pino build && pnpm --filter @axiomhq/pino build:cjs`
- `pnpm --filter @axiomhq/winston test -- --runInBand && pnpm --filter @axiomhq/winston typecheck && pnpm --filter @axiomhq/winston build && pnpm --filter @axiomhq/winston build:cjs`

## CI

- CI now runs the build, Winston example, and integration matrices on Node 20.x, 22.x, and 24.x.

## Follow-up

Axiom ingest/API CORS configuration must allow the `X-Axiom-Client` request header for browser ingestion paths.