### PR TITLE
fix: handle non-JSON responses and unserializable logs

### DIFF
--- a/packages/js/src/fetchClient.ts
+++ b/packages/js/src/fetchClient.ts
@@ -1,6 +1,30 @@
 import fetchRetry from 'fetch-retry';
 import { parseLimitFromResponse, Limit, LimitType } from './limit.js';
 
+async function parseErrorMessage(resp: Response): Promise<string> {
+  const body = await resp.text().catch(() => '');
+  if (body.length === 0) {
+    return `Unknown ${resp.status} error`;
+  }
+
+  try {
+    const payload: unknown = JSON.parse(body);
+    if (
+      typeof payload === 'object' &&
+      payload !== null &&
+      'message' in payload &&
+      typeof payload.message === 'string' &&
+      payload.message.length > 0
+    ) {
+      return payload.message;
+    }
+  } catch {
+    // Non-JSON error responses are returned as plain text.
+  }
+
+  return body;
+}
+
 export class FetchClient {
   constructor(public config: { headers: HeadersInit; baseUrl: string; timeout: number; fetch?: typeof globalThis.fetch }) {}
 
@@ -43,8 +67,7 @@ export class FetchClient {
     } else if (resp.status === 401) {
       return Promise.reject(new Error('forbidden'));
     } else if (resp.status >= 400) {
-      const payload = (await resp.json()) as { message: string };
-      return Promise.reject(new Error(payload.message));
+      return Promise.reject(new Error(await parseErrorMessage(resp)));
     }
 
     return (await resp.json()) as T;

--- a/packages/js/test/unit/fetchClient.test.ts
+++ b/packages/js/test/unit/fetchClient.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { FetchClient } from '../../src/fetchClient';
+
+function createClient(response: () => Response): FetchClient {
+  return new FetchClient({
+    baseUrl: 'https://api.example.com',
+    headers: {},
+    timeout: 1000,
+    fetch: vi.fn(async () => response()),
+  });
+}
+
+describe('FetchClient error responses', () => {
+  it('uses the message from a JSON error response', async () => {
+    const client = createClient(() => Response.json({ message: 'invalid request' }, { status: 400 }));
+
+    await expect(client.get('/datasets')).rejects.toThrow('invalid request');
+  });
+
+  it('uses a non-JSON error response as the error message', async () => {
+    const client = createClient(() => new Response('upstream unavailable', { status: 502 }));
+
+    await expect(client.get('/datasets')).rejects.toThrow('upstream unavailable');
+  });
+
+  it('provides a status-aware message for an empty error response', async () => {
+    const client = createClient(() => new Response(null, { status: 400 }));
+
+    await expect(client.get('/datasets')).rejects.toThrow('Unknown 400 error');
+  });
+});

--- a/packages/logging/src/internal/safe-stringify.ts
+++ b/packages/logging/src/internal/safe-stringify.ts
@@ -1,128 +1,35 @@
 const CIRCULAR = '[Circular]';
-const FUNCTION = '[Function]';
 const UNSERIALIZABLE = '[Unserializable]';
 
-type Constructor = new (...args: never[]) => object;
+function replaceCircularReferences() {
+  const ancestors: object[] = [];
 
-function readStringProperty(value: object, property: string): string | undefined {
-  try {
-    const result = (value as Record<string, unknown>)[property];
-    return typeof result === 'string' ? result : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function isInstanceOf(value: object, constructor: unknown): boolean {
-  if (typeof constructor !== 'function') {
-    return false;
-  }
-
-  try {
-    return value instanceof (constructor as Constructor);
-  } catch {
-    return false;
-  }
-}
-
-function serializeDOMNode(value: object): string | undefined {
-  if (isInstanceOf(value, (globalThis as { Element?: unknown }).Element)) {
-    const tagName = readStringProperty(value, 'tagName');
-    return tagName ? `[Element ${tagName}]` : '[Element]';
-  }
-
-  if (isInstanceOf(value, (globalThis as { Node?: unknown }).Node)) {
-    const nodeName = readStringProperty(value, 'nodeName');
-    return nodeName ? `[Node ${nodeName}]` : '[Node]';
-  }
-
-  return undefined;
-}
-
-function serializeError(error: Error, ancestors: WeakSet<object>): Record<string, unknown> {
-  const result: Record<string, unknown> = {
-    name: readStringProperty(error, 'name') ?? 'Error',
-    message: readStringProperty(error, 'message') ?? '',
-  };
-  const stack = readStringProperty(error, 'stack');
-  if (stack !== undefined) {
-    result.stack = stack;
-  }
-
-  try {
-    const cause = (error as { cause?: unknown }).cause;
-    if (cause !== undefined) {
-      result.cause = sanitize(cause, ancestors);
-    }
-  } catch {
-    result.cause = UNSERIALIZABLE;
-  }
-
-  return result;
-}
-
-function sanitize(value: unknown, ancestors: WeakSet<object>): unknown {
-  if (value === null || value === undefined) {
-    return value;
-  }
-
-  if (typeof value === 'function') {
-    return FUNCTION;
-  }
-  if (typeof value === 'bigint') {
-    return value.toString();
-  }
-  if (typeof value !== 'object') {
-    return value;
-  }
-
-  const domNode = serializeDOMNode(value);
-  if (domNode !== undefined) {
-    return domNode;
-  }
-
-  if (ancestors.has(value)) {
-    return CIRCULAR;
-  }
-
-  ancestors.add(value);
-  try {
-    if (value instanceof Error) {
-      return serializeError(value, ancestors);
-    }
-    if (value instanceof Date) {
-      return value.toISOString();
-    }
-    if (value instanceof RegExp) {
+  return function (this: object, _key: string, value: unknown): unknown {
+    if (typeof value === 'bigint') {
       return value.toString();
     }
-    if (Array.isArray(value)) {
-      return value.map((item) => sanitize(item, ancestors));
+    if (typeof value !== 'object' || value === null) {
+      return value;
     }
 
-    const result: Record<string, unknown> = {};
-    for (const key of Object.keys(value)) {
-      try {
-        result[key] = sanitize((value as Record<string, unknown>)[key], ancestors);
-      } catch {
-        result[key] = UNSERIALIZABLE;
-      }
+    while (ancestors.length > 0 && ancestors.at(-1) !== this) {
+      ancestors.pop();
     }
-    return result;
-  } catch {
-    return UNSERIALIZABLE;
-  } finally {
-    ancestors.delete(value);
-  }
+    if (ancestors.includes(value)) {
+      return CIRCULAR;
+    }
+
+    ancestors.push(value);
+    return value;
+  };
 }
 
 /**
- * Serializes arbitrary log fields without allowing one unsupported value to
- * prevent the rest of the event batch from being delivered.
+ * JSON.stringify with circular-reference and bigint handling.
  */
 export function safeStringify(value: unknown): string {
   try {
-    return JSON.stringify(sanitize(value, new WeakSet())) ?? 'null';
+    return JSON.stringify(value, replaceCircularReferences()) ?? 'null';
   } catch {
     return JSON.stringify(UNSERIALIZABLE);
   }

--- a/packages/logging/src/internal/safe-stringify.ts
+++ b/packages/logging/src/internal/safe-stringify.ts
@@ -1,0 +1,129 @@
+const CIRCULAR = '[Circular]';
+const FUNCTION = '[Function]';
+const UNSERIALIZABLE = '[Unserializable]';
+
+type Constructor = new (...args: never[]) => object;
+
+function readStringProperty(value: object, property: string): string | undefined {
+  try {
+    const result = (value as Record<string, unknown>)[property];
+    return typeof result === 'string' ? result : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function isInstanceOf(value: object, constructor: unknown): boolean {
+  if (typeof constructor !== 'function') {
+    return false;
+  }
+
+  try {
+    return value instanceof (constructor as Constructor);
+  } catch {
+    return false;
+  }
+}
+
+function serializeDOMNode(value: object): string | undefined {
+  if (isInstanceOf(value, (globalThis as { Element?: unknown }).Element)) {
+    const tagName = readStringProperty(value, 'tagName');
+    return tagName ? `[Element ${tagName}]` : '[Element]';
+  }
+
+  if (isInstanceOf(value, (globalThis as { Node?: unknown }).Node)) {
+    const nodeName = readStringProperty(value, 'nodeName');
+    return nodeName ? `[Node ${nodeName}]` : '[Node]';
+  }
+
+  return undefined;
+}
+
+function serializeError(error: Error, ancestors: WeakSet<object>): Record<string, unknown> {
+  const result: Record<string, unknown> = {
+    name: readStringProperty(error, 'name') ?? 'Error',
+    message: readStringProperty(error, 'message') ?? '',
+  };
+  const stack = readStringProperty(error, 'stack');
+  if (stack !== undefined) {
+    result.stack = stack;
+  }
+
+  try {
+    const cause = (error as { cause?: unknown }).cause;
+    if (cause !== undefined) {
+      result.cause = sanitize(cause, ancestors);
+    }
+  } catch {
+    result.cause = UNSERIALIZABLE;
+  }
+
+  return result;
+}
+
+function sanitize(value: unknown, ancestors: WeakSet<object>): unknown {
+  if (value === null || value === undefined) {
+    return value;
+  }
+
+  if (typeof value === 'function') {
+    return FUNCTION;
+  }
+  if (typeof value === 'bigint') {
+    return value.toString();
+  }
+  if (typeof value !== 'object') {
+    return value;
+  }
+
+  const domNode = serializeDOMNode(value);
+  if (domNode !== undefined) {
+    return domNode;
+  }
+
+  if (ancestors.has(value)) {
+    return CIRCULAR;
+  }
+
+  ancestors.add(value);
+  try {
+    if (value instanceof Error) {
+      return serializeError(value, ancestors);
+    }
+    if (value instanceof Date) {
+      return value.toISOString();
+    }
+    if (value instanceof RegExp) {
+      return value.toString();
+    }
+    if (Array.isArray(value)) {
+      return value.map((item) => sanitize(item, ancestors));
+    }
+
+    const result: Record<string, unknown> = {};
+    for (const key of Object.keys(value)) {
+      try {
+        result[key] = sanitize((value as Record<string, unknown>)[key], ancestors);
+      } catch {
+        result[key] = UNSERIALIZABLE;
+      }
+    }
+    return result;
+  } catch {
+    return UNSERIALIZABLE;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+/**
+ * Serializes arbitrary log fields without allowing one unsupported value to
+ * prevent the rest of the event batch from being delivered.
+ */
+export function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(sanitize(value, new WeakSet())) ?? 'null';
+  } catch {
+    return JSON.stringify(UNSERIALIZABLE);
+  }
+}

--- a/packages/logging/src/transports/console.ts
+++ b/packages/logging/src/transports/console.ts
@@ -1,6 +1,8 @@
 import { Transport } from './transport';
 import { LogEvent, LogLevel, LogLevelValue } from '../logger';
 import { isBrowser } from '../runtime';
+import { safeStringify } from '../internal/safe-stringify';
+
 export interface ConsoleTransportConfig {
   prettyPrint?: boolean;
   logLevel?: LogLevel;
@@ -57,7 +59,7 @@ export class ConsoleTransport implements Transport {
       }
       let msg = `${ev.level} - ${ev.message}`;
       if (hasFields) {
-        msg += ' ' + JSON.stringify(ev.fields);
+        msg += ' ' + safeStringify(ev.fields);
       }
       console.log(msg);
       return;

--- a/packages/logging/src/transports/fetch.ts
+++ b/packages/logging/src/transports/fetch.ts
@@ -1,5 +1,6 @@
 import { Transport } from './transport';
 import { LogEvent, LogLevelValue, LogLevel } from '../logger';
+import { safeStringify } from '../internal/safe-stringify';
 
 interface FetchConfig {
   input: Parameters<typeof fetch>[0];
@@ -52,7 +53,7 @@ export class SimpleFetchTransport implements Transport {
         'Content-Type': 'application/json',
       },
       ...this.fetchConfig.init,
-      body: JSON.stringify(this.events),
+      body: safeStringify(this.events),
     })
       .then(async (res) => {
         if (!res.ok) {

--- a/packages/logging/test/unit/internal/safe-stringify.test.ts
+++ b/packages/logging/test/unit/internal/safe-stringify.test.ts
@@ -15,58 +15,7 @@ describe('safeStringify', () => {
     });
   });
 
-  it('serializes values that JSON.stringify cannot represent safely', () => {
-    const cause = new Error('root cause');
-    const error = new Error('request failed', { cause });
-
-    const result = JSON.parse(
-      safeStringify({
-        bigint: 42n,
-        callback: () => undefined,
-        error,
-      }),
-    );
-
-    expect(result.bigint).toBe('42');
-    expect(result.callback).toBe('[Function]');
-    expect(result.error).toMatchObject({
-      name: 'Error',
-      message: 'request failed',
-      cause: {
-        name: 'Error',
-        message: 'root cause',
-      },
-    });
-  });
-
-  it('replaces DOM elements before traversing framework references', () => {
-    const previousElement = (globalThis as { Element?: unknown }).Element;
-    class FakeElement {
-      tagName = 'IMG';
-      frameworkReference = { element: this };
-    }
-    (globalThis as { Element?: unknown }).Element = FakeElement;
-
-    try {
-      expect(JSON.parse(safeStringify({ element: new FakeElement() }))).toEqual({
-        element: '[Element IMG]',
-      });
-    } finally {
-      (globalThis as { Element?: unknown }).Element = previousElement;
-    }
-  });
-
-  it('isolates properties whose getters throw', () => {
-    const value = {
-      ok: true,
-      get broken(): never {
-        throw new Error('no access');
-      },
-    };
-
-    expect(JSON.parse(safeStringify(value))).toEqual({
-      ok: true,
-      broken: '[Unserializable]',
-    });
+  it('serializes bigint values as strings', () => {
+    expect(JSON.parse(safeStringify({ value: 42n }))).toEqual({ value: '42' });
   });
 });

--- a/packages/logging/test/unit/internal/safe-stringify.test.ts
+++ b/packages/logging/test/unit/internal/safe-stringify.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { safeStringify } from '../../../src/internal/safe-stringify';
+
+describe('safeStringify', () => {
+  it('replaces circular references without changing shared references', () => {
+    const shared = { value: 1 };
+    const circular: { self?: unknown } = {};
+    circular.self = circular;
+
+    expect(JSON.parse(safeStringify({ first: shared, second: shared, circular }))).toEqual({
+      first: shared,
+      second: shared,
+      circular: { self: '[Circular]' },
+    });
+  });
+
+  it('serializes values that JSON.stringify cannot represent safely', () => {
+    const cause = new Error('root cause');
+    const error = new Error('request failed', { cause });
+
+    const result = JSON.parse(
+      safeStringify({
+        bigint: 42n,
+        callback: () => undefined,
+        error,
+      }),
+    );
+
+    expect(result.bigint).toBe('42');
+    expect(result.callback).toBe('[Function]');
+    expect(result.error).toMatchObject({
+      name: 'Error',
+      message: 'request failed',
+      cause: {
+        name: 'Error',
+        message: 'root cause',
+      },
+    });
+  });
+
+  it('replaces DOM elements before traversing framework references', () => {
+    const previousElement = (globalThis as { Element?: unknown }).Element;
+    class FakeElement {
+      tagName = 'IMG';
+      frameworkReference = { element: this };
+    }
+    (globalThis as { Element?: unknown }).Element = FakeElement;
+
+    try {
+      expect(JSON.parse(safeStringify({ element: new FakeElement() }))).toEqual({
+        element: '[Element IMG]',
+      });
+    } finally {
+      (globalThis as { Element?: unknown }).Element = previousElement;
+    }
+  });
+
+  it('isolates properties whose getters throw', () => {
+    const value = {
+      ok: true,
+      get broken(): never {
+        throw new Error('no access');
+      },
+    };
+
+    expect(JSON.parse(safeStringify(value))).toEqual({
+      ok: true,
+      broken: '[Unserializable]',
+    });
+  });
+});

--- a/packages/logging/test/unit/transports/console.test.ts
+++ b/packages/logging/test/unit/transports/console.test.ts
@@ -35,6 +35,15 @@ describe('ConsoleTransport', () => {
       expect(consoleSpy).toHaveBeenCalledWith('info - test message {"userId":"123"}');
     });
 
+    it('should safely include circular fields in log output', () => {
+      const fields: Record<string, unknown> = {};
+      fields.self = fields;
+
+      transport.log([createLogEvent(LogLevel.info, 'test message', fields)]);
+
+      expect(consoleSpy).toHaveBeenCalledWith('info - test message {"self":"[Circular]"}');
+    });
+
     it('should handle multiple log events', () => {
       const events = [createLogEvent(LogLevel.info, 'first message'), createLogEvent(LogLevel.error, 'second message')];
       transport.log(events);

--- a/packages/logging/test/unit/transports/fetch.test.ts
+++ b/packages/logging/test/unit/transports/fetch.test.ts
@@ -231,6 +231,51 @@ describe('SimpleFetchTransport', () => {
     });
   });
 
+  describe('non-JSON-native payloads', () => {
+    it('flushes the full batch when a log contains a circular reference', async () => {
+      let receivedLogs: any[] = [];
+      server.use(
+        http.post(API_URL, async ({ request }) => {
+          receivedLogs = (await request.json()) as any[];
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      transport = new SimpleFetchTransport({ input: API_URL });
+      const circularFields: Record<string, unknown> = {};
+      circularFields.self = circularFields;
+
+      transport.log([
+        createLogEvent(LogLevel.info, 'before'),
+        createLogEvent(LogLevel.info, 'circular', circularFields),
+        createLogEvent(LogLevel.info, 'after'),
+      ]);
+      await transport.flush();
+
+      expect(receivedLogs.map((log) => log.message)).toEqual(['before', 'circular', 'after']);
+      expect(receivedLogs[1].fields.self).toBe('[Circular]');
+    });
+
+    it('does not cause an unhandled rejection during auto-flush', async () => {
+      const unhandledRejection = vi.fn();
+      process.on('unhandledRejection', unhandledRejection);
+      server.use(http.post(API_URL, () => HttpResponse.json({ success: true })));
+
+      try {
+        transport = new SimpleFetchTransport({ input: API_URL, autoFlush: { durationMs: 500 } });
+        const circularFields: Record<string, unknown> = {};
+        circularFields.self = circularFields;
+        transport.log([createLogEvent(LogLevel.info, 'circular', circularFields)]);
+
+        await vi.advanceTimersByTimeAsync(500);
+
+        expect(unhandledRejection).not.toHaveBeenCalled();
+      } finally {
+        process.off('unhandledRejection', unhandledRejection);
+      }
+    });
+  });
+
   describe('log level filtering', () => {
     it('should filter logs based on logLevel', async () => {
       let receivedLogs: any[] = [];

--- a/packages/react/src/web-vitals.tsx
+++ b/packages/react/src/web-vitals.tsx
@@ -4,6 +4,131 @@ import * as React from 'react';
 import { onLCP, onFID, onCLS, onINP, onFCP, onTTFB } from 'web-vitals';
 import type { Metric } from 'web-vitals';
 
+const SCALAR_ENTRY_PROPERTIES = [
+  'name',
+  'entryType',
+  'startTime',
+  'duration',
+  'renderTime',
+  'loadTime',
+  'size',
+  'id',
+  'url',
+  'value',
+  'hadRecentInput',
+  'lastInputTime',
+  'processingStart',
+  'processingEnd',
+  'interactionId',
+  'cancelable',
+  'activationStart',
+  'workerStart',
+  'redirectStart',
+  'redirectEnd',
+  'fetchStart',
+  'domainLookupStart',
+  'domainLookupEnd',
+  'connectStart',
+  'secureConnectionStart',
+  'connectEnd',
+  'requestStart',
+  'responseStart',
+  'responseEnd',
+  'transferSize',
+  'encodedBodySize',
+  'decodedBodySize',
+  'nextHopProtocol',
+  'type',
+] as const;
+
+const RECT_PROPERTIES = ['x', 'y', 'width', 'height', 'top', 'right', 'bottom', 'left'] as const;
+
+function readProperty(value: object, property: string): unknown {
+  try {
+    return (value as Record<string, unknown>)[property];
+  } catch {
+    return undefined;
+  }
+}
+
+function normalizeNode(node: unknown): Record<string, string> | undefined {
+  if (typeof node !== 'object' || node === null) {
+    return undefined;
+  }
+
+  const result: Record<string, string> = {};
+  for (const property of ['nodeName', 'tagName', 'id', 'className'] as const) {
+    const value = readProperty(node, property);
+    if (typeof value === 'string' && value.length > 0) {
+      result[property] = value;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function normalizeRect(rect: unknown): Record<string, number> | undefined {
+  if (typeof rect !== 'object' || rect === null) {
+    return undefined;
+  }
+
+  const result: Record<string, number> = {};
+  for (const property of RECT_PROPERTIES) {
+    const value = readProperty(rect, property);
+    if (typeof value === 'number') {
+      result[property] = value;
+    }
+  }
+
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function normalizeLayoutShiftSources(sources: unknown): Array<Record<string, unknown>> | undefined {
+  if (!Array.isArray(sources)) {
+    return undefined;
+  }
+
+  return sources.map((source) => {
+    if (typeof source !== 'object' || source === null) {
+      return {};
+    }
+
+    return {
+      node: normalizeNode(readProperty(source, 'node')),
+      previousRect: normalizeRect(readProperty(source, 'previousRect')),
+      currentRect: normalizeRect(readProperty(source, 'currentRect')),
+    };
+  });
+}
+
+function normalizePerformanceEntry(entry: PerformanceEntry): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+
+  for (const property of SCALAR_ENTRY_PROPERTIES) {
+    const value = readProperty(entry, property);
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+      result[property] = value;
+    }
+  }
+
+  const element = normalizeNode(readProperty(entry, 'element'));
+  if (element !== undefined) {
+    result.element = element;
+  }
+
+  const target = normalizeNode(readProperty(entry, 'target'));
+  if (target !== undefined) {
+    result.target = target;
+  }
+
+  const sources = normalizeLayoutShiftSources(readProperty(entry, 'sources'));
+  if (sources !== undefined) {
+    result.sources = sources;
+  }
+
+  return result;
+}
+
 export function useReportWebVitals(pushMetrics: (metric: Metric) => void, flushMetrics: () => void) {
   const pushMetricsRef = React.useRef(pushMetrics);
   const flushMetricsRef = React.useRef(flushMetrics);
@@ -30,7 +155,10 @@ export function useReportWebVitals(pushMetrics: (metric: Metric) => void, flushM
 
 export const transformWebVitalsMetric = (metric: Metric): Record<string, any> => {
   return {
-    webVital: metric,
+    webVital: {
+      ...metric,
+      entries: metric.entries?.map(normalizePerformanceEntry) ?? [],
+    },
     _time: new Date().getTime(),
     source: 'web-vital',
     path: window.location.pathname,

--- a/packages/react/test/unit/web-vitals.test.tsx
+++ b/packages/react/test/unit/web-vitals.test.tsx
@@ -67,18 +67,150 @@ describe('Web Vitals', () => {
       const mockMetric = {
         name: 'CLS',
         value: 0.1,
+        rating: 'good',
+        delta: 0.1,
         id: 'test',
-      };
+        navigationType: 'navigate',
+        entries: [],
+      } satisfies Metric;
       const now = 1234567890;
       vi.spyOn(Date.prototype, 'getTime').mockReturnValue(now);
 
-      const result = transformWebVitalsMetric(mockMetric as Metric);
+      const result = transformWebVitalsMetric(mockMetric);
 
       expect(result).toEqual({
-        webVital: mockMetric,
+        webVital: {
+          ...mockMetric,
+          entries: [],
+        },
         _time: now,
         source: 'web-vital',
         path: '/test-path',
+      });
+    });
+
+    it('should normalize LCP entries without retaining DOM elements', () => {
+      const element: Record<string, unknown> = {
+        nodeName: 'IMG',
+        tagName: 'IMG',
+        id: 'hero',
+        className: 'hero-image',
+      };
+      element.reactFiber = { stateNode: element };
+      const metric = {
+        name: 'LCP',
+        value: 2400,
+        entries: [
+          {
+            name: '',
+            entryType: 'largest-contentful-paint',
+            startTime: 2400,
+            duration: 0,
+            renderTime: 2400,
+            loadTime: 2100,
+            size: 120000,
+            url: 'https://example.com/hero.jpg',
+            element,
+          },
+        ],
+      } as unknown as Metric;
+
+      const result = transformWebVitalsMetric(metric);
+
+      expect(result.webVital.entries).toEqual([
+        {
+          name: '',
+          entryType: 'largest-contentful-paint',
+          startTime: 2400,
+          duration: 0,
+          renderTime: 2400,
+          loadTime: 2100,
+          size: 120000,
+          url: 'https://example.com/hero.jpg',
+          element: {
+            nodeName: 'IMG',
+            tagName: 'IMG',
+            id: 'hero',
+            className: 'hero-image',
+          },
+        },
+      ]);
+      expect(() => JSON.stringify(result)).not.toThrow();
+    });
+
+    it('should normalize layout shift sources', () => {
+      const metric = {
+        name: 'CLS',
+        value: 0.1,
+        entries: [
+          {
+            name: '',
+            entryType: 'layout-shift',
+            startTime: 100,
+            duration: 0,
+            value: 0.1,
+            hadRecentInput: false,
+            sources: [
+              {
+                node: { nodeName: 'DIV', tagName: 'DIV', id: 'content' },
+                previousRect: { x: 0, y: 0, width: 100, height: 20 },
+                currentRect: { x: 0, y: 20, width: 100, height: 20 },
+              },
+            ],
+          },
+        ],
+      } as unknown as Metric;
+
+      const result = transformWebVitalsMetric(metric);
+
+      expect(result.webVital.entries[0]).toMatchObject({
+        entryType: 'layout-shift',
+        value: 0.1,
+        hadRecentInput: false,
+        sources: [
+          {
+            node: { nodeName: 'DIV', tagName: 'DIV', id: 'content' },
+            previousRect: { x: 0, y: 0, width: 100, height: 20 },
+            currentRect: { x: 0, y: 20, width: 100, height: 20 },
+          },
+        ],
+      });
+    });
+
+    it('should preserve navigation timing diagnostics', () => {
+      const metric = {
+        name: 'TTFB',
+        value: 350,
+        entries: [
+          {
+            name: 'https://example.com/',
+            entryType: 'navigation',
+            startTime: 0,
+            duration: 800,
+            fetchStart: 5,
+            domainLookupStart: 10,
+            domainLookupEnd: 20,
+            connectStart: 20,
+            secureConnectionStart: 25,
+            connectEnd: 40,
+            requestStart: 45,
+            responseStart: 350,
+            responseEnd: 500,
+            transferSize: 2048,
+            nextHopProtocol: 'h2',
+          },
+        ],
+      } as unknown as Metric;
+
+      const result = transformWebVitalsMetric(metric);
+
+      expect(result.webVital.entries[0]).toMatchObject({
+        entryType: 'navigation',
+        requestStart: 45,
+        responseStart: 350,
+        responseEnd: 500,
+        transferSize: 2048,
+        nextHopProtocol: 'h2',
       });
     });
   });
@@ -116,13 +248,17 @@ describe('Web Vitals', () => {
         name: 'CLS',
         value: 0.1,
         id: 'test',
+        entries: [],
       };
 
       const onCLSCallback = vi.mocked(webVitals.onCLS).mock.calls[0][0] as Function;
       onCLSCallback(mockMetric);
 
       expect(mockLogger.raw).toHaveBeenCalledWith({
-        webVital: mockMetric,
+        webVital: {
+          ...mockMetric,
+          entries: [],
+        },
         _time: now,
         source: 'web-vital',
         path: '/test-path',


### PR DESCRIPTION
## Summary

- read HTTP error response bodies once, then extract JSON `message` values or fall back to plain text and a status-aware message for empty bodies
- normalize Web Vitals performance entries before logging them, retaining diagnostic timings, compact element metadata, and layout-shift rectangles without retaining live DOM nodes
- use a small shared JSON serializer that handles circular references and `bigint` values in fetch and non-pretty console transports
- keep the simple fetch transport's existing retry and queue semantics
- add regression coverage for both failure modes

## Why

This consolidates the fixes proposed in #353 and #427.

The response fallback in #353 attempts to call `text()` after a failed `json()` read, but response bodies are single-use. Reading text first makes both JSON and non-JSON error handling reliable.

The logging failure in #427 is triggered when raw browser performance entries retain DOM references decorated with React fiber back-references. This PR normalizes those entries at the React integration boundary instead of making the logging transport DOM-aware. The remaining serializer is a generic safeguard for arbitrary circular user fields.

The implementation also addresses #427's unresolved review feedback by avoiding a separate batch capture/requeue policy in `SimpleFetchTransport`.

## Impact

HTTP callers now receive the server's useful error text instead of a JSON parsing exception. Web Vitals users retain useful LCP, CLS, INP/FID, FCP, and TTFB diagnostics while emitted events remain JSON-safe. Logging callers can also submit generic circular fields without an unhandled auto-flush rejection.

## Validation

- `pnpm --filter @axiomhq/js test` — 135 tests passed
- `pnpm --filter @axiomhq/logging test` — 54 tests passed
- `pnpm --filter @axiomhq/react exec vitest run` — 23 tests passed
- `pnpm --filter @axiomhq/js lint`
- `pnpm --filter @axiomhq/logging lint`
- `pnpm --filter @axiomhq/react lint`
- `pnpm --filter @axiomhq/logging typecheck`
- `pnpm --filter @axiomhq/react typecheck`
- `pnpm --filter @axiomhq/js build`
- `pnpm --filter @axiomhq/logging build`
- `pnpm --filter @axiomhq/react build`

## Known baseline issue

`pnpm --filter @axiomhq/js typecheck` still reports the existing `BodyInit` / `BlobPart` buffer incompatibilities in unchanged `packages/js/src/client.ts` (lines 88 and 153).