### PR TITLE
fix: stabilize integration CI diagnostics

### DIFF
--- a/integration/package.json
+++ b/integration/package.json
@@ -9,7 +9,7 @@
     "build": "tsc -b",
     "format": "eslint 'src/**/*.{js,ts}' --quiet --fix",
     "lint": "eslint 'src/**/*.{js,ts}'",
-    "integration": "vitest run src/*"
+    "integration": "vitest run src/* --no-file-parallelism"
   },
   "dependencies": {
     "@axiomhq/js": "workspace:*",

--- a/packages/js/src/fetchClient.ts
+++ b/packages/js/src/fetchClient.ts
@@ -25,8 +25,31 @@ async function parseErrorMessage(resp: Response): Promise<string> {
   return body;
 }
 
+function requestEndpoint(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url.split('?')[0];
+  }
+}
+
+export class AxiomRequestError extends Error {
+  constructor(
+    public status: number,
+    public method: string,
+    public endpoint: string,
+    message: string,
+  ) {
+    super(`${method} ${endpoint} failed with ${status}: ${message}`);
+    this.name = 'AxiomRequestError';
+    Object.setPrototypeOf(this, AxiomRequestError.prototype);
+  }
+}
+
 export class FetchClient {
-  constructor(public config: { headers: HeadersInit; baseUrl: string; timeout: number; fetch?: typeof globalThis.fetch }) {}
+  constructor(
+    public config: { headers: HeadersInit; baseUrl: string; timeout: number; fetch?: typeof globalThis.fetch },
+  ) {}
 
   async doReq<T>(
     endpoint: string,
@@ -67,7 +90,9 @@ export class FetchClient {
     } else if (resp.status === 401) {
       return Promise.reject(new Error('forbidden'));
     } else if (resp.status >= 400) {
-      return Promise.reject(new Error(await parseErrorMessage(resp)));
+      return Promise.reject(
+        new AxiomRequestError(resp.status, method, requestEndpoint(finalUrl), await parseErrorMessage(resp)),
+      );
     }
 
     return (await resp.json()) as T;

--- a/packages/js/test/unit/fetchClient.test.ts
+++ b/packages/js/test/unit/fetchClient.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { FetchClient } from '../../src/fetchClient';
+import { AxiomRequestError, FetchClient } from '../../src/fetchClient';
 
 function createClient(response: () => Response): FetchClient {
   return new FetchClient({
@@ -15,7 +15,15 @@ describe('FetchClient error responses', () => {
   it('uses the message from a JSON error response', async () => {
     const client = createClient(() => Response.json({ message: 'invalid request' }, { status: 400 }));
 
-    await expect(client.get('/datasets')).rejects.toThrow('invalid request');
+    const error = await client.get('/datasets?referrer=secret').catch((error: unknown) => error);
+
+    expect(error).toBeInstanceOf(AxiomRequestError);
+    expect(error).toMatchObject({
+      status: 400,
+      method: 'GET',
+      endpoint: '/datasets',
+    });
+    expect(error).toHaveProperty('message', 'GET /datasets failed with 400: invalid request');
   });
 
   it('uses a non-JSON error response as the error message', async () => {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
         "declaration": true,
         "declarationMap": true,
         "sourceMap": true,
+        "inlineSources": true,
         "strict": true,
         "skipLibCheck": true,
         "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Summary

- run integration test files sequentially so suites do not compete for the test organization's limited dataset capacity
- embed TypeScript sources in generated sourcemaps so Vitest can resolve source locations in CI
- add a structured `AxiomRequestError` with HTTP status, method, and query-free endpoint context
- cover the richer request error while ensuring query parameters are not exposed

## Root cause

The integration test files execute in parallel by default. Each suite creates its own dataset, but the shared test organization only allowed two dataset creations at a time. As a result, exactly two suites completed setup while the others failed with an opaque `Bad Request`; the successful suites changed between Node jobs.

The sourcemap messages were a separate, non-fatal issue. Generated maps referenced paths such as `../../../src/client.ts`, which resolve outside the package, and did not include `sourcesContent`. Vitest therefore warned that the maps pointed to missing files and displayed misleading stack paths.

Finally, generic SDK request errors only surfaced the response body, which made the HTTP operation and status unavailable in CI output.

## Changes

- pass `--no-file-parallelism` to the integration Vitest command
- enable `inlineSources` for generated TypeScript sourcemaps
- report request failures as `<METHOD> <PATH> failed with <STATUS>: <MESSAGE>`
- retain structured `status`, `method`, and `endpoint` properties on request errors
- strip query strings from the reported endpoint

## Verification

- `pnpm exec vitest run packages/js/test/unit/fetchClient.test.ts`
- `pnpm --filter @axiomhq/js lint`
- `pnpm --dir integration lint`
- ESM and CJS builds for `@axiomhq/js` and `@axiomhq/winston`
- verified generated ESM/CJS maps embed all source content
- `pnpm --dir integration exec vitest list src --no-file-parallelism` collects the integration suite without missing-sourcemap warnings
- `git diff --check`

## Notes

This is a stacked PR targeting the head branch of #433 so its diff contains only the CI stabilization commit. Live integration execution was not available locally because the Axiom CI secrets are only present in GitHub Actions.
