### PR TITLE
test(pino): reproduce onError worker clone failure

### DIFF
--- a/packages/pino/package.json
+++ b/packages/pino/package.json
@@ -44,6 +44,7 @@
     "pino-abstract-transport": "^3.0.0"
   },
   "devDependencies": {
-    "@repo/eslint-config": "workspace:*"
+    "@repo/eslint-config": "workspace:*",
+    "pino": "^10.3.1"
   }
 }

--- a/packages/pino/test/unit/worker-transport.spec.ts
+++ b/packages/pino/test/unit/worker-transport.spec.ts
@@ -1,0 +1,20 @@
+import { fileURLToPath } from 'node:url';
+import pino from 'pino';
+import { describe, expect, it } from 'vitest';
+
+describe('pino worker transport', () => {
+  it('accepts a custom Axiom onError callback', () => {
+    const target = fileURLToPath(new URL('../../src/index.ts', import.meta.url));
+
+    expect(() =>
+      pino.transport({
+        target,
+        options: {
+          dataset: 'test-dataset',
+          token: 'test-token',
+          onError: () => undefined,
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -509,6 +509,9 @@ importers:
       '@repo/eslint-config':
         specifier: workspace:*
         version: link:../../internal/eslint-config
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
 
   packages/react:
     dependencies:
@@ -9512,7 +9515,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.9.0)(jsdom@27.4.0)(msw@2.6.2(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.6.2(@types/node@20.19.39)(typescript@5.4.5))(vite@7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.4))
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -9577,7 +9580,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vitest: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@22.19.11)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.9.0)(jsdom@27.4.0)(msw@2.6.2(@types/node@22.19.11)(typescript@5.9.3))(vite@7.3.5(@types/node@22.19.11)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.4))
+      vitest: 4.1.9(@edge-runtime/vm@5.0.0)(@types/node@20.19.39)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(happy-dom@20.9.0)(jsdom@29.1.1)(msw@2.6.2(@types/node@20.19.39)(typescript@5.4.5))(vite@7.3.5(@types/node@20.19.39)(jiti@2.7.0)(lightningcss@1.33.0)(tsx@4.21.0)(yaml@2.8.4))
 
   '@vitest/utils@4.1.9':
     dependencies:


### PR DESCRIPTION
## What changed

- Add a focused Pino worker-transport regression test that passes an Axiom `onError` callback.
- Add Pino as a development dependency of `@axiomhq/pino` so the public worker transport path can be exercised.

## Why

Pino serializes worker transport options before loading the transport. Function-valued options are not structured-cloneable, so supplying the supported `onError` callback currently throws a `DataCloneError` before the Axiom transport starts.

This draft captures the behavior in a minimal test so a follow-up implementation can make the worker path safe without losing error handling.

## Impact

There is no production behavior change in this PR. The new regression test intentionally fails until the transport handles the callback across the worker boundary.

## Validation

- `pnpm --filter @axiomhq/pino typecheck` — passes
- `pnpm --filter @axiomhq/pino exec vitest run test/unit/worker-transport.spec.ts` — intentionally fails with `DataCloneError: () => void 0 could not be cloned.`