### PR TITLE
fix: configure release-please versioning

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -14,32 +14,32 @@
   "packages": {
     "packages/js": {
       "release-type": "node",
-      "versioning-strategy": "always-bump-patch",
+      "versioning": "default",
       "include-v-in-tag": false
     },
     "packages/pino": {
       "release-type": "node",
-      "versioning-strategy": "always-bump-patch",
+      "versioning": "default",
       "include-v-in-tag": false
     },
     "packages/winston": {
       "release-type": "node",
-      "versioning-strategy": "always-bump-patch",
+      "versioning": "default",
       "include-v-in-tag": false
     },
     "packages/logging": {
       "release-type": "node",
-      "versioning-strategy": "always-bump-patch",
+      "versioning": "default",
       "include-v-in-tag": false
     },
     "packages/react": {
       "release-type": "node",
-      "versioning-strategy": "always-bump-patch",
+      "versioning": "default",
       "include-v-in-tag": false
     },
     "packages/nextjs": {
       "release-type": "node",
-      "versioning-strategy": "always-bump-patch",
+      "versioning": "default",
       "include-v-in-tag": false
     },
     "packages/tanstack-start": {


### PR DESCRIPTION
## Summary

- replace the unsupported `versioning-strategy` manifest keys with `versioning`
- use Release Please's default semantic versioning strategy for all linked core and integration packages

## Why

The existing `versioning-strategy` properties are action inputs, not valid manifest package configuration, so Release Please silently ignored them. Using the supported `versioning: default` setting makes breaking Conventional Commits produce major releases, features produce minor releases, and fixes produce patch releases.

The already-merged breaking change in #406 also lacked Conventional Commit metadata. Its PR body has been updated separately with a `BEGIN_COMMIT_OVERRIDE` block so Release Please can recognize it on the next run.

## Impact

After this PR merges, the push to `main` will rerun Release Please. Combined with the #406 commit override and the linked `core` versions configuration, the pending release PR should recalculate `js`, `pino`, and `winston` as `2.0.0`.

## Validation

- `jq empty release-please-config.json`
- `pnpm exec prettier --check release-please-config.json`
- validated `release-please-config.json` against the official Release Please v17.6.0 JSON schema using `ajv-cli`
- `git diff --check`