### PR TITLE
fix(logging): bound fetch transport buffering and retries

### DIFF
--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -23,6 +23,20 @@ logger.info('Hello World!');
 
 `AxiomJSTransport` appends logging package usage to the Axiom client's `X-Axiom-Client` header. With the example above, requests use an `X-Axiom-Client` header like `axiom-js/<version> axiom-logging/<version> my-app/1.0`.
 
+## Proxy transport delivery
+
+`ProxyTransport` uses `SimpleFetchTransport` to send logs to your HTTP endpoint. Delivery is best effort:
+
+- The transport retains at most 1,000 queued events plus one batch of at most 1,000 events in flight. When the queue fills, it drops the oldest queued events to retain recent activity. The in-flight batch is unchanged. These limits bound event counts, not bytes or individual event sizes.
+- With `autoFlush: true`, the first queued event starts a two-second timer. Later events do not postpone it, and a full queue starts a send immediately when no batch is in flight. `{ durationMs }` sets a different delay. With `autoFlush` omitted or `false`, sending starts only when you call `flush()`.
+- Requests run one at a time. Network failures and HTTP 429, 500, 502, 503, and 504 receive at most one retry after a one-second delay. A longer `Retry-After` is honored. Both attempts and their delays share a ten-second deadline.
+- Permanent failures, caller cancellation, timeout, or an exhausted retry drop the batch. If `Retry-After` cannot fit within the deadline, the batch is dropped without retrying early. Subsequent batches also respect that server cooldown and are dropped if they cannot wait within their own deadline.
+- Drops produce `console.warn` diagnostics containing counts by reason, without log contents. Warnings are emitted at most once every 30 seconds per transport; suppressed counts are included in the next warning when more drops occur.
+
+`flush()` waits for events accepted before that call to be sent or dropped. Later events do not extend that caller's target, and concurrent calls share the serial sender. A resolved flush does not guarantee delivery. Retrying after a lost response can duplicate events that the server already accepted.
+
+Earlier versions retained failed batches for a later flush. The bounded retry policy above replaces that behavior, so a prolonged outage can cause data loss without allowing the backlog to grow indefinitely.
+
 ## Schema validation
 
 `Logger` can validate and type log `fields` using any validator that implements Standard Schema v1 (for example `zod`).
@@ -71,6 +85,7 @@ const logger = new Logger({
 ```
 
 Unknown key behavior depends on your schema configuration:
+
 - strict object schemas (like `z.object(...).strict()`) reject unknown keys
 - non-strict schemas may allow them
 

--- a/packages/logging/src/transports/fetch.ts
+++ b/packages/logging/src/transports/fetch.ts
@@ -4,64 +4,221 @@ import { safeStringify } from '../internal/safe-stringify';
 
 interface FetchConfig {
   input: Parameters<typeof fetch>[0];
-  init?: Omit<Parameters<typeof fetch>[1], 'body'>;
+  init?: Omit<NonNullable<Parameters<typeof fetch>[1]>, 'body'>;
   autoFlush?: boolean | { durationMs: number };
   logLevel?: LogLevel;
 }
 
+const MAX_EVENTS = 1_000;
+const BATCH_TIMEOUT_MS = 10_000;
+const RETRY_DELAY_MS = 1_000;
+const WARNING_INTERVAL_MS = 30_000;
+const RETRYABLE_STATUSES = new Set([429, 500, 502, 503, 504]);
+
+type QueuedEvent = { sequence: number; event: LogEvent };
+type FlushWaiter = { through: number; resolve: () => void };
+
+function retryAfterMs(value: string | null): number | undefined {
+  if (value === null) return undefined;
+  if (/^\d+$/.test(value.trim())) {
+    const delay = Number(value) * 1_000;
+    return Number.isFinite(delay) ? delay : undefined;
+  }
+  const date = Date.parse(value);
+  return Number.isNaN(date) ? undefined : Math.max(0, date - Date.now());
+}
+
 export class SimpleFetchTransport implements Transport {
   private fetchConfig: FetchConfig;
-  private events: LogEvent[] = [];
-  private timer: NodeJS.Timeout | null = null;
+  private events: QueuedEvent[] = [];
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private flushing = false;
+  private inFlight: QueuedEvent[] = [];
+  private sequence = 0;
+  private requestedThrough = 0;
+  private waiters = new Set<FlushWaiter>();
+  private retryAfterUntil = 0;
+  private lastWarningAt = -Infinity;
+  private dropped: Record<string, number> = {};
 
   constructor(config: FetchConfig) {
     this.fetchConfig = config;
   }
 
   log: Transport['log'] = (logs) => {
-    const filteredLogs = logs.filter(
-      (log) =>
-        LogLevelValue[(log.level as LogLevel) ?? LogLevel.info] >=
-        LogLevelValue[this.fetchConfig.logLevel ?? LogLevel.info],
-    );
-
-    this.events.push(...filteredLogs);
-
-    if (typeof this.fetchConfig.autoFlush === 'undefined' || this.fetchConfig.autoFlush === false) {
-      return;
+    let dropped = 0;
+    for (const event of logs) {
+      if (
+        !(
+          LogLevelValue[(event.level as LogLevel) ?? LogLevel.info] >=
+          LogLevelValue[this.fetchConfig.logLevel ?? LogLevel.info]
+        )
+      ) {
+        continue;
+      }
+      if (this.events.length === MAX_EVENTS) {
+        this.events.shift();
+        dropped += 1;
+      }
+      this.events.push({ sequence: ++this.sequence, event });
     }
+    this.settleWaiters();
+    if (dropped > 0) this.reportDrop('overflow', dropped);
 
-    if (this.timer) {
-      clearTimeout(this.timer);
+    const autoFlush = this.fetchConfig.autoFlush;
+    if (autoFlush === undefined || autoFlush === false || this.events.length === 0) return;
+
+    if (this.events.length === MAX_EVENTS && !this.flushing) {
+      void this.flush();
+    } else if (this.timer === null) {
+      const delay = typeof autoFlush === 'boolean' ? 2_000 : autoFlush.durationMs;
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        void this.flush();
+      }, delay);
     }
-
-    const flushDelay = typeof this.fetchConfig.autoFlush === 'boolean' ? 2000 : this.fetchConfig.autoFlush.durationMs;
-
-    this.timer = setTimeout(() => {
-      this.flush();
-    }, flushDelay);
   };
 
-  async flush() {
-    if (this.events.length <= 0) {
-      return;
+  /** Wait for events accepted before this call to be sent or explicitly dropped. */
+  async flush(): Promise<void> {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
     }
+    const through = this.sequence;
+    if (through < this.oldestOutstanding()) return;
 
-    await fetch(this.fetchConfig.input, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      ...this.fetchConfig.init,
-      body: safeStringify(this.events),
-    })
-      .then(async (res) => {
-        if (!res.ok) {
-          console.error(await res.text());
-          throw new Error('Failed to flush logs');
+    const completed = new Promise<void>((resolve) => this.waiters.add({ through, resolve }));
+    this.requestedThrough = through;
+    if (!this.flushing) {
+      // Set this before entering the async worker, including when fetch throws synchronously.
+      this.flushing = true;
+      void this.drain();
+    }
+    await completed;
+  }
+
+  private oldestOutstanding(): number {
+    return this.inFlight[0]?.sequence ?? this.events[0]?.sequence ?? this.sequence + 1;
+  }
+
+  private settleWaiters(): void {
+    const oldest = this.oldestOutstanding();
+    for (const waiter of this.waiters) {
+      if (waiter.through < oldest) {
+        this.waiters.delete(waiter);
+        waiter.resolve();
+      }
+    }
+  }
+
+  private async drain(): Promise<void> {
+    try {
+      while (this.events.length > 0 && this.events[0].sequence <= this.requestedThrough) {
+        const next = this.events.findIndex((event) => event.sequence > this.requestedThrough);
+        this.inFlight = this.events.splice(0, next < 0 ? this.events.length : next);
+        const reason = await this.sendBatch(this.inFlight.map(({ event }) => event));
+        if (reason) this.reportDrop(reason, this.inFlight.length);
+        this.inFlight = [];
+        this.settleWaiters();
+      }
+    } finally {
+      this.flushing = false;
+    }
+  }
+
+  /** One retry, sharing a deadline with the first attempt and any backoff. */
+  private async sendBatch(events: LogEvent[]): Promise<string | undefined> {
+    const controller = new AbortController();
+    const { input, init } = this.fetchConfig;
+    const callerSignal = init?.signal !== undefined ? init.signal : input instanceof Request ? input.signal : undefined;
+    const abortFromCaller = () => controller.abort();
+    callerSignal?.addEventListener('abort', abortFromCaller, { once: true });
+    if (callerSignal?.aborted) controller.abort();
+    const deadline = Date.now() + BATCH_TIMEOUT_MS;
+    const timeout = setTimeout(() => controller.abort(), BATCH_TIMEOUT_MS);
+    let onAbort: () => void = () => {};
+    const aborted = new Promise<never>((_, reject) => {
+      onAbort = () => reject(new Error('Log batch aborted'));
+      controller.signal.addEventListener('abort', onAbort, { once: true });
+    });
+    // A log's toJSON can cancel the caller signal before we enter a request or delay race.
+    void aborted.catch(() => {});
+    const pause = async (delay: number) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([new Promise<void>((resolve) => (timer = setTimeout(resolve, delay))), aborted]);
+      } finally {
+        clearTimeout(timer);
+      }
+    };
+
+    try {
+      const body = safeStringify(events);
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        if (controller.signal.aborted || Date.now() >= deadline) {
+          return callerSignal?.aborted ? 'cancelled' : 'timeout';
         }
-        this.events = [];
-      })
-      .catch(console.error);
+        const cooldown = Math.max(0, this.retryAfterUntil - Date.now());
+        if (cooldown >= deadline - Date.now()) return 'server backoff';
+        if (cooldown > 0) await pause(cooldown);
+        if (controller.signal.aborted || Date.now() >= deadline) {
+          return callerSignal?.aborted ? 'cancelled' : 'timeout';
+        }
+
+        let response: Response;
+        try {
+          response = await Promise.race([
+            Promise.resolve().then(() =>
+              fetch(this.fetchConfig.input, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                ...this.fetchConfig.init,
+                body,
+                signal: controller.signal,
+              }),
+            ),
+            aborted,
+          ]);
+        } catch {
+          if (controller.signal.aborted) return callerSignal?.aborted ? 'cancelled' : 'timeout';
+          if (attempt === 1) return 'network error';
+          if (RETRY_DELAY_MS >= deadline - Date.now()) return 'timeout';
+          await pause(RETRY_DELAY_MS);
+          continue;
+        }
+
+        // We only need the status and headers; do not buffer an arbitrary response body.
+        void response.body?.cancel().catch(() => {});
+        if (response.ok) return;
+        const retryDelay = retryAfterMs(response.headers.get('Retry-After'));
+        if (RETRYABLE_STATUSES.has(response.status) && retryDelay !== undefined) {
+          this.retryAfterUntil = Math.max(this.retryAfterUntil, Date.now() + retryDelay);
+        }
+        if (!RETRYABLE_STATUSES.has(response.status) || attempt === 1) return `HTTP ${response.status}`;
+        const delay = Math.max(RETRY_DELAY_MS, retryDelay ?? 0);
+        if (delay >= deadline - Date.now()) return 'server backoff';
+        await pause(delay);
+      }
+    } catch {
+      return callerSignal?.aborted ? 'cancelled' : controller.signal.aborted ? 'timeout' : 'request error';
+    } finally {
+      clearTimeout(timeout);
+      callerSignal?.removeEventListener('abort', abortFromCaller);
+      controller.signal.removeEventListener('abort', onAbort);
+    }
+  }
+
+  private reportDrop(reason: string, count: number): void {
+    this.dropped[reason] = (this.dropped[reason] ?? 0) + count;
+    if (Date.now() - this.lastWarningAt < WARNING_INTERVAL_MS) return;
+    const dropped = this.dropped;
+    this.dropped = {};
+    this.lastWarningAt = Date.now();
+    try {
+      console.warn('[Axiom] Dropped log events:', dropped);
+    } catch {
+      // Diagnostics must not break the application or stop future flushes.
+    }
   }
 }

--- a/packages/logging/test/unit/transports/fetch-delivery.test.ts
+++ b/packages/logging/test/unit/transports/fetch-delivery.test.ts
@@ -1,0 +1,400 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LogLevel } from '../../../src/logger';
+import { SimpleFetchTransport } from '../../../src/transports/fetch';
+import { createLogEvent } from '../../lib/mock';
+
+const API_URL = 'https://api.example.com/logs';
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+function response(status = 204, headers?: HeadersInit): Response {
+  return new Response(null, { status, headers });
+}
+
+async function settlePromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+function requestBody(fetchMock: ReturnType<typeof vi.fn>, call = 0): Array<{ message: string }> {
+  return JSON.parse(String(fetchMock.mock.calls[call][1]?.body));
+}
+
+describe('SimpleFetchTransport delivery', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    fetchMock = vi.fn(() => Promise.resolve(response()));
+    vi.stubGlobal('fetch', fetchMock);
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('snapshots each flush and keeps requests serial', async () => {
+    const firstRequest = deferred<Response>();
+    fetchMock.mockImplementationOnce(() => firstRequest.promise);
+
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'first')]);
+    const firstFlush = transport.flush();
+    await settlePromises();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(requestBody(fetchMock)).toEqual([expect.objectContaining({ message: 'first' })]);
+
+    transport.log([createLogEvent(LogLevel.info, 'second')]);
+    let secondFlushResolved = false;
+    const secondFlush = transport.flush().then(() => {
+      secondFlushResolved = true;
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    firstRequest.resolve(response());
+    await firstFlush;
+    await settlePromises();
+
+    expect(secondFlushResolved).toBe(false);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestBody(fetchMock, 1)).toEqual([expect.objectContaining({ message: 'second' })]);
+
+    await secondFlush;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('limits queued events to 1000 and drops the oldest queued events', async () => {
+    const firstRequest = deferred<Response>();
+    fetchMock.mockImplementationOnce(() => firstRequest.promise);
+
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log(Array.from({ length: 1_000 }, (_, i) => createLogEvent(LogLevel.info, `inflight-${i}`)));
+    const firstFlush = transport.flush();
+    await settlePromises();
+    expect(requestBody(fetchMock)).toHaveLength(1_000);
+
+    transport.log(Array.from({ length: 1_000 }, (_, i) => createLogEvent(LogLevel.info, `queued-${i}`)));
+    transport.log([createLogEvent(LogLevel.info, 'newest')]);
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(JSON.stringify(warnSpy.mock.calls)).not.toContain('queued-999');
+
+    firstRequest.resolve(response());
+    await firstFlush;
+
+    const secondFlush = transport.flush();
+    await secondFlush;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestBody(fetchMock, 1)).toHaveLength(1_000);
+    expect(requestBody(fetchMock, 1)[0].message).toBe('queued-1');
+    expect(requestBody(fetchMock, 1).at(-1)?.message).toBe('newest');
+  });
+
+  it('throttles drop warnings and reports aggregated reasons without event payloads', async () => {
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log(Array.from({ length: 1_000 }, (_, i) => createLogEvent(LogLevel.info, `kept-${i}`)));
+
+    transport.log([createLogEvent(LogLevel.info, 'dropped-first')]);
+    transport.log([createLogEvent(LogLevel.info, 'dropped-second')]);
+    await vi.advanceTimersByTimeAsync(29_999);
+    transport.log([createLogEvent(LogLevel.info, 'dropped-third')]);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(1);
+    transport.log([createLogEvent(LogLevel.info, 'dropped-fourth')]);
+    expect(warnSpy).toHaveBeenCalledTimes(2);
+
+    const warningText = JSON.stringify(warnSpy.mock.calls);
+    expect(warningText).toMatch(/overflow|queue|drop/i);
+    expect(warnSpy).toHaveBeenNthCalledWith(2, expect.any(String), { overflow: 3 });
+    expect(warningText).not.toContain('dropped-first');
+    expect(warningText).not.toContain('dropped-second');
+    expect(warningText).not.toContain('dropped-third');
+    expect(warningText).not.toContain('dropped-fourth');
+  });
+
+  it.each([429, 500, 502, 503, 504])('retries transient HTTP %s once after 1000ms', async (status) => {
+    fetchMock.mockResolvedValueOnce(response(status)).mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent()]);
+
+    const flushPromise = transport.flush();
+    await settlePromises();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors Retry-After seconds for transient responses', async () => {
+    fetchMock.mockResolvedValueOnce(response(429, { 'Retry-After': '2' })).mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent()]);
+    const flushPromise = transport.flush();
+    await settlePromises();
+
+    await vi.advanceTimersByTimeAsync(1_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('honors Retry-After HTTP dates', async () => {
+    vi.setSystemTime(new Date('2026-09-09T00:00:00.000Z'));
+    const retryAt = new Date(Date.now() + 3_000).toUTCString();
+    fetchMock.mockResolvedValueOnce(response(429, { 'Retry-After': retryAt })).mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent()]);
+    const flushPromise = transport.flush();
+    await settlePromises();
+
+    await vi.advanceTimersByTimeAsync(2_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a batch immediately when Retry-After exceeds the 10000ms batch budget', async () => {
+    fetchMock.mockResolvedValueOnce(response(429, { 'Retry-After': '11' }));
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'too-late')]);
+
+    const flushPromise = transport.flush();
+    await settlePromises();
+    await flushPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.runAllTimersAsync();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([400, 401])('does not retry permanent HTTP %s responses', async (status) => {
+    fetchMock.mockResolvedValueOnce(response(status));
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent()]);
+
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.runAllTimersAsync();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops a batch after its one retry and keeps the worker available', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(500))
+      .mockResolvedValueOnce(response(500))
+      .mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'exhausted')]);
+    const failedFlush = transport.flush();
+    await settlePromises();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await failedFlush;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    transport.log([createLogEvent(LogLevel.info, 'after-exhaustion')]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(requestBody(fetchMock, 2)[0].message).toBe('after-exhaustion');
+  });
+
+  it('remembers server cooldown across batches and suppresses requests until it expires', async () => {
+    fetchMock
+      .mockResolvedValueOnce(response(429, { 'Retry-After': '5' }))
+      .mockResolvedValueOnce(response())
+      .mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'first')]);
+    const firstFlush = transport.flush();
+    await settlePromises();
+
+    transport.log([createLogEvent(LogLevel.info, 'during-cooldown')]);
+    const duringCooldownFlush = transport.flush();
+    await settlePromises();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await vi.advanceTimersByTimeAsync(4_999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    await firstFlush;
+    await duringCooldownFlush;
+    transport.log([createLogEvent(LogLevel.info, 'after-cooldown')]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(requestBody(fetchMock, 1)[0].message).toBe('first');
+    expect(requestBody(fetchMock, 2)[0].message).toBe('during-cooldown');
+    expect(requestBody(fetchMock, 3)[0].message).toBe('after-cooldown');
+  });
+
+  it('aborts a retry when the caller signal aborts and remains usable for later flushes', async () => {
+    const controller = new AbortController();
+    const init: RequestInit = { signal: controller.signal };
+    fetchMock.mockResolvedValueOnce(response(500)).mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, init, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'aborted')]);
+    const flushPromise = transport.flush();
+    await settlePromises();
+
+    controller.abort();
+    await flushPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    init.signal = undefined;
+    transport.log([createLogEvent(LogLevel.info, 'future')]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(requestBody(fetchMock, 1)[0].message).toBe('future');
+  });
+
+  it('aborts a hung request at the 10000ms batch deadline, including retry time', async () => {
+    let retrySignal: AbortSignal | undefined;
+    fetchMock
+      .mockResolvedValueOnce(response(500))
+      .mockImplementationOnce((_input: unknown, requestInit: RequestInit = {}) => {
+        retrySignal = requestInit.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          requestInit.signal?.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')));
+        });
+      });
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent()]);
+    const flushPromise = transport.flush();
+    await settlePromises();
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    await settlePromises();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(8_999);
+    expect(retrySignal?.aborted).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    await flushPromise;
+    expect(retrySignal?.aborted).toBe(true);
+  });
+
+  it('recovers after synchronous fetch failures and does not leave the worker stuck', async () => {
+    fetchMock
+      .mockImplementationOnce(() => {
+        throw new Error('first synchronous failure');
+      })
+      .mockImplementationOnce(() => {
+        throw new Error('second synchronous failure');
+      })
+      .mockResolvedValueOnce(response());
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'failed')]);
+    const firstFlush = transport.flush();
+    await settlePromises();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1_000);
+    await firstFlush;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    transport.log([createLogEvent(LogLevel.info, 'recovered')]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(requestBody(fetchMock, 2)[0].message).toBe('recovered');
+  });
+
+  it('finishes a flush even when every request produces more logs', async () => {
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    fetchMock.mockImplementation(() => {
+      // Stop after ten calls so the old drain-until-empty implementation fails without hanging.
+      if (fetchMock.mock.calls.length < 10) transport.log([createLogEvent(LogLevel.info, 'later')]);
+      return Promise.resolve(response());
+    });
+    transport.log([createLogEvent(LogLevel.info, 'initial')]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('settles a flush whose queued events were evicted after its in-flight batch completes', async () => {
+    const firstRequest = deferred<Response>();
+    fetchMock.mockImplementationOnce(() => firstRequest.promise);
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent(LogLevel.info, 'in-flight')]);
+    const firstFlush = transport.flush();
+    transport.log([createLogEvent(LogLevel.info, 'evicted')]);
+    const secondFlush = transport.flush();
+    transport.log(Array.from({ length: 1_000 }, () => createLogEvent(LogLevel.info, 'later')));
+    firstRequest.resolve(response());
+    await Promise.all([firstFlush, secondFlush]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('retains a long server cooldown after dropping the failed batch', async () => {
+    fetchMock.mockResolvedValueOnce(response(429, { 'Retry-After': '60' }));
+    const transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+    transport.log([createLogEvent()]);
+    await transport.flush();
+    transport.log([createLogEvent()]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(60_000);
+    transport.log([createLogEvent()]);
+    await transport.flush();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('inherits cancellation from a Request input', async () => {
+    const controller = new AbortController();
+    const input = new Request(API_URL, { signal: controller.signal });
+    fetchMock.mockResolvedValueOnce(response(500));
+    const transport = new SimpleFetchTransport({ input, autoFlush: false });
+    transport.log([createLogEvent()]);
+    const flushPromise = transport.flush();
+    await vi.advanceTimersByTimeAsync(0);
+    controller.abort();
+    await flushPromise;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('does not send with an already aborted signal or leave timeout timers behind', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const transport = new SimpleFetchTransport({ input: API_URL, init: { signal: controller.signal } });
+    transport.log([createLogEvent()]);
+    await transport.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('handles cancellation triggered by log serialization without an unhandled rejection', async () => {
+    const controller = new AbortController();
+    const transport = new SimpleFetchTransport({ input: API_URL, init: { signal: controller.signal } });
+    transport.log([
+      createLogEvent(LogLevel.info, 'cancel during serialization', {
+        toJSON: () => {
+          controller.abort();
+          return {};
+        },
+      }),
+    ]);
+    await transport.flush();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/packages/logging/test/unit/transports/fetch.test.ts
+++ b/packages/logging/test/unit/transports/fetch.test.ts
@@ -88,19 +88,44 @@ describe('SimpleFetchTransport', () => {
       expect(requestSpy).not.toHaveBeenCalled();
     });
 
-    it('should handle request errors gracefully', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    it('drops permanent request failures and continues with later logs', async () => {
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const receivedMessages: string[][] = [];
       server.use(
-        http.post(API_URL, () => {
-          return HttpResponse.error();
+        http.post(API_URL, async ({ request }) => {
+          const logs = (await request.json()) as Array<{ message: string }>;
+          receivedMessages.push(logs.map((log) => log.message));
+          return receivedMessages.length === 1
+            ? HttpResponse.json({ error: true }, { status: 400 })
+            : HttpResponse.json({ success: true });
         }),
       );
 
-      transport.log([createLogEvent()]);
+      transport.log([createLogEvent(LogLevel.error, 'failed')]);
+      await transport.flush();
+      transport.log([createLogEvent(LogLevel.info, 'next')]);
       await transport.flush();
 
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      expect(consoleWarnSpy).toHaveBeenCalled();
+      expect(receivedMessages).toEqual([['failed'], ['next']]);
+      consoleWarnSpy.mockRestore();
+    });
+
+    it('allows subclasses to override flush', async () => {
+      class CustomFetchTransport extends SimpleFetchTransport {
+        flushCalls = 0;
+
+        override async flush(): Promise<void> {
+          this.flushCalls += 1;
+          await super.flush();
+        }
+      }
+
+      const customTransport = new CustomFetchTransport({ input: API_URL, autoFlush: false });
+      customTransport.log([createLogEvent()]);
+      await customTransport.flush();
+
+      expect(customTransport.flushCalls).toBe(1);
     });
   });
 
@@ -150,7 +175,7 @@ describe('SimpleFetchTransport', () => {
       expect(requestSpy).toHaveBeenCalledTimes(1);
     });
 
-    it('should reset auto-flush timer when new logs are added', async () => {
+    it('should not postpone auto-flush when new logs are added', async () => {
       let receivedBody: any;
       server.use(
         http.post(API_URL, async ({ request }) => {
@@ -170,12 +195,99 @@ describe('SimpleFetchTransport', () => {
       transport.log([createLogEvent(LogLevel.info, 'second')]);
 
       await vi.advanceTimersByTimeAsync(500);
-      expect(receivedBody).toBeUndefined();
-
-      await vi.advanceTimersByTimeAsync(500);
       expect(receivedBody).toBeDefined();
       expect(receivedBody[0].message).toBe('first');
       expect(receivedBody[1].message).toBe('second');
+    });
+
+    it('makes concurrent flush callers wait for their own snapshots', async () => {
+      const receivedMessages: string[][] = [];
+      let resolveFirstRequest: (() => void) | undefined;
+      let resolveSecondRequest: (() => void) | undefined;
+      let markFirstRequestStarted: (() => void) | undefined;
+      let markSecondRequestStarted: (() => void) | undefined;
+      const firstRequestStarted = new Promise<void>((resolve) => {
+        markFirstRequestStarted = resolve;
+      });
+      const secondRequestStarted = new Promise<void>((resolve) => {
+        markSecondRequestStarted = resolve;
+      });
+      const releaseFirstRequest = new Promise<void>((resolve) => {
+        resolveFirstRequest = resolve;
+      });
+      const releaseSecondRequest = new Promise<void>((resolve) => {
+        resolveSecondRequest = resolve;
+      });
+
+      server.use(
+        http.post(API_URL, async ({ request }) => {
+          const logs = (await request.json()) as Array<{ message: string }>;
+          receivedMessages.push(logs.map((log) => log.message));
+
+          if (receivedMessages.length === 1) {
+            markFirstRequestStarted?.();
+            await releaseFirstRequest;
+          } else if (receivedMessages.length === 2) {
+            markSecondRequestStarted?.();
+            await releaseSecondRequest;
+          }
+
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+      transport.log([createLogEvent(LogLevel.info, 'first')]);
+      const firstFlush = transport.flush();
+      await firstRequestStarted;
+
+      transport.log([createLogEvent(LogLevel.info, 'second')]);
+      const secondFlush = transport.flush();
+      const thirdFlush = transport.flush();
+      const firstFlushResolved = vi.fn();
+      const secondFlushResolved = vi.fn();
+      const thirdFlushResolved = vi.fn();
+      void firstFlush.then(firstFlushResolved);
+      void secondFlush.then(secondFlushResolved);
+      void thirdFlush.then(thirdFlushResolved);
+
+      expect(receivedMessages).toEqual([['first']]);
+
+      resolveFirstRequest?.();
+      await secondRequestStarted;
+      await Promise.resolve();
+
+      expect(firstFlushResolved).toHaveBeenCalledOnce();
+      expect(secondFlushResolved).not.toHaveBeenCalled();
+      expect(thirdFlushResolved).not.toHaveBeenCalled();
+
+      resolveSecondRequest?.();
+      await Promise.all([firstFlush, secondFlush, thirdFlush]);
+
+      expect(receivedMessages).toEqual([['first'], ['second']]);
+      expect(firstFlushResolved).toHaveBeenCalledOnce();
+      expect(secondFlushResolved).toHaveBeenCalledOnce();
+      expect(thirdFlushResolved).toHaveBeenCalledOnce();
+    });
+
+    it('bounds the queue and request body', async () => {
+      let receivedMessages: string[] = [];
+      server.use(
+        http.post(API_URL, async ({ request }) => {
+          const logs = (await request.json()) as Array<{ message: string }>;
+          receivedMessages = logs.map((log) => log.message);
+          return HttpResponse.json({ success: true });
+        }),
+      );
+
+      transport = new SimpleFetchTransport({ input: API_URL, autoFlush: false });
+      transport.log(Array.from({ length: 1_001 }, (_, index) => createLogEvent(LogLevel.info, `event-${index}`)));
+
+      await transport.flush();
+
+      expect(receivedMessages).toHaveLength(1_000);
+      expect(receivedMessages[0]).toBe('event-1');
+      expect(receivedMessages.at(-1)).toBe('event-1000');
     });
 
     it('should auto-flush with custom duration from config object', async () => {

--- a/packages/logging/test/unit/transports/proxy-transport.test.ts
+++ b/packages/logging/test/unit/transports/proxy-transport.test.ts
@@ -66,7 +66,7 @@ describe('ProxyTransport', () => {
     });
 
     it('should handle request errors gracefully', async () => {
-      const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       server.use(
         http.post(PROXY_URL, () => {
           return HttpResponse.error();
@@ -80,8 +80,8 @@ describe('ProxyTransport', () => {
       transport.log([createLogEvent()]);
       await transport.flush();
 
-      expect(consoleErrorSpy).toHaveBeenCalled();
-      consoleErrorSpy.mockRestore();
+      expect(consoleWarnSpy).toHaveBeenCalledWith(expect.any(String), { 'network error': 1 });
+      consoleWarnSpy.mockRestore();
     });
   });
 });


### PR DESCRIPTION
Sustained logging could postpone the fetch transport's timer indefinitely and grow its queue without a limit. Overlapping flushes could also duplicate in-flight payloads or clear events added during a request.

This change gives SimpleFetchTransport (and ProxyTransport) explicit buffering and delivery behavior:

- Keep at most 1,000 queued events plus one in-flight batch of at most 1,000. Overflow evicts the oldest queued events, preserving recent context. This bounds event counts, not bytes.
- Start auto-flush from the first queued event; later logs do not postpone it. A full queue triggers a send when the sender is idle.
- Serialize sends. Each flush caller waits only for its pre-call events to be sent or explicitly dropped, so a continuous producer cannot extend that caller's target indefinitely.
- Retry network failures and HTTP 429/500/502/503/504 once, after at least one second. Both attempts and backoff share a ten-second deadline. Honor Retry-After across batches; drop a batch if the server cooldown cannot fit within its deadline.
- Drop permanent failures, cancellations, timeouts, and exhausted retries. Report counts by reason through console.warn, at most once every 30 seconds per transport, without log contents.

Delivery remains best effort. Earlier versions retained failed batches for a later flush; this change replaces that behavior with bounded retries and explicit drops. Retrying after a lost response can produce duplicates if the server already accepted the request. The README documents these tradeoffs.

Validation: 96 logging tests pass, including regressions for overflow order, first-event timers, concurrent flush snapshots, continuous producers, retry exhaustion, Retry-After, request deadlines, caller cancellation, synchronous fetch failures, and warning throttling. Logging typecheck, lint, and ESM/CJS build pass. CI covers Node 24 and 26, integration tests, and deployed E2E tests.
