### PR TITLE
fix(js): avoid Blob.stream() in gzip ingest path to stop BlobReader leak

### DIFF
--- a/packages/js/src/client.ts
+++ b/packages/js/src/client.ts
@@ -150,7 +150,22 @@ class BaseClient extends HTTPClient {
     }
 
     if (typeof data === 'string' || data instanceof Uint8Array) {
-      return new Blob([data]).stream();
+      /*
+       * Deliberately NOT `new Blob([data]).stream()`: on Node 24 every Blob
+       * read leaks a native BlobReader held by a V8 global handle while the
+       * process stays busy, and each leaked reader pins the AsyncContextFrame
+       * captured when the flush was scheduled. In AsyncLocalStorage-heavy
+       * hosts (e.g. self-hosted Next.js) that frame is the full request
+       * context, so every batch flush permanently retained one request until
+       * the process went fully idle. See #508 and #471.
+       */
+      const bytes = typeof data === 'string' ? new TextEncoder().encode(data) : data;
+      return new ReadableStream({
+        start(controller) {
+          controller.enqueue(bytes);
+          controller.close();
+        },
+      });
     }
 
     return null;


### PR DESCRIPTION
Fixes #508, related to #471.

## Problem

The gzip path in `encodeIngestPayload` feeds `CompressionStream` from `new Blob([data]).stream()`. On Node 24, every Blob read leaks a native `BlobReader` held by a V8 global handle while the process has ongoing activity, and each leaked reader also pins the `AsyncContextFrame` captured when the flush was scheduled. In AsyncLocalStorage-based hosts (e.g. self-hosted Next.js) that frame is the full request context, so every batch flush permanently retained one request (IncomingMessage, ServerResponse, socket, timers) until the process went completely idle. Under continuous traffic memory grows without bound. Full analysis with heap-snapshot retainer chains in #508.

## Fix

Feed `CompressionStream` from a plain single-chunk `ReadableStream` instead of a Blob. No behavior change otherwise: gzip stays on, the code stays isomorphic (no node:zlib dependency).

## Validation

Measured on Node 24.17.0 with a 400-request burst plus a 1-request/5s trickle against a Next.js app, heap snapshot after 3 minutes:

| | Retained request contexts | Live BlobReaders |
| --- | --- | --- |
| Before | 292 | 572 |
| After | 4 | 0 |

All 136 existing unit tests pass (`vitest run test/unit`).
`pnpm build`, `pnpm test`, and `pnpm lint` all pass on the full monorepo (the `@axiomhq/js` unit suite is 136 tests).