### PR TITLE
fix(security): update linkify-it to 5.0.2

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4193,6 +4193,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5109,8 +5110,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
@@ -11877,7 +11878,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -11949,7 +11950,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0


### PR DESCRIPTION
Updates the transitive `linkify-it` dependency from 5.0.0 to 5.0.2 via pnpm’s recursive transitive update; no override is needed because the existing `markdown-it` dependency range accepts the patched v5 release.

Alerts fixed:
- https://github.com/axiomhq/axiom-js/security/dependabot/181
- https://github.com/axiomhq/axiom-js/security/dependabot/178

Dependency path: `@tanstack/typedoc-config` -> `typedoc` -> `markdown-it` -> `linkify-it` (development tooling).

Release notes reviewed:
- https://github.com/markdown-it/linkify-it/releases/tag/5.0.1 (first fix for the scan-loop complexity advisory)
- https://github.com/markdown-it/linkify-it/releases/tag/5.0.2 (fixes the `mailto:` validator quadratic scan issue)

The update stays on the v5 API line; no source compatibility changes were needed.

Validation: `pnpm install --frozen-lockfile` (pnpm 10.4.1); functional URL/email matching smoke test passed; `node /tmp/axiom-verify-alerts.cjs /tmp/axiom-security-linkify-it linkify-it` reports no vulnerable resolved versions. Full repository tests/builds were not repeated for this lockfile-only development dependency update.

Combined validation of the 15 security PRs (#511–#525) passed: frozen pnpm install, full application/package builds, CJS builds, typechecks, lint, and all unit tests. Every resolved version was checked against all 25 open Dependabot advisory ranges; none remained vulnerable. Lockfiles were generated by pnpm throughout.

