### PR TITLE
fix(security): update markdown-it to 14.3.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4193,6 +4193,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -5109,8 +5110,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
 
   local-pkg@0.5.1:
     resolution: {integrity: sha512-9rrA30MRRP3gBD3HTGnC6cDFpaE1kVDWxWgqWJUN0RvDNAo+Nz/9GxB+nHOH0ifbVFy0hSA1V6vFDvnx54lTEQ==}
@@ -5177,8 +5178,8 @@ packages:
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.3.1:
+    resolution: {integrity: sha512-4Ej49aYTDFIQ+uBkfX8GBvJGccoARxxPep+7aWTs55ozbjQJpW9M26Fe53vnGgvLeVzva/amzjQQaQu9w0vMhA==}
     hasBin: true
 
   math-intrinsics@1.1.0:
@@ -11877,7 +11878,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.2:
     dependencies:
       uc.micro: 2.1.0
 
@@ -11945,11 +11946,11 @@ snapshots:
 
   make-error@1.3.6: {}
 
-  markdown-it@14.1.1:
+  markdown-it@14.3.1:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.2
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -13257,7 +13258,7 @@ snapshots:
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
-      markdown-it: 14.1.1
+      markdown-it: 14.3.1
       minimatch: 9.0.9
       typescript: 5.9.3
       yaml: 2.8.4


### PR DESCRIPTION
Updates the transitive `markdown-it` dependency from 14.1.1 to 14.3.1 via pnpm’s recursive transitive update; no override is needed because the existing `typedoc` dependency range accepts the patched v14 release.

Alert fixed:
- https://github.com/axiomhq/axiom-js/security/dependabot/164

Dependency path: `@tanstack/typedoc-config` -> `typedoc` -> `markdown-it` (development tooling).

Release notes reviewed:
- https://github.com/markdown-it/markdown-it/blob/master/CHANGELOG.md (14.2.0 fixes smartquotes quadratic performance and bumps linkify-it to 5.0.1; 14.3.0 bumps linkify-it to 5.0.2 and contains parser/build fixes)
- https://www.npmjs.com/package/markdown-it?activeTab=versions (14.3.1 is the subsequent v14 patch release)

The update stays on the v14 API line. The lockfile resolves linkify-it to 5.0.2 because markdown-it 14.3.1 requires the safe v5 range; the separate linkify-it PR updates that package independently. Merge https://github.com/axiomhq/axiom-js/pull/514 first to avoid an overlapping lockfile hunk. No source compatibility changes were needed.

Validation: `pnpm install --frozen-lockfile` (pnpm 10.4.1); targeted ESM smoke test with typographer and linkification passed; `node /tmp/axiom-verify-alerts.cjs /tmp/axiom-security-markdown-it markdown-it` reports no vulnerable resolved versions. Full repository tests/builds were not repeated for this lockfile-only development dependency update.

Combined validation of the 15 security PRs (#511–#525) passed: frozen pnpm install, full application/package builds, CJS builds, typechecks, lint, and all unit tests. Every resolved version was checked against all 25 open Dependabot advisory ranges; none remained vulnerable. Lockfiles were generated by pnpm throughout.

