### PR TITLE
fix(deps): update @humanfs/node for security alert

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,12 +1352,16 @@ packages:
   '@gerrit0/mini-shiki@3.23.0':
     resolution: {integrity: sha512-bEMORlG0cqdjVyCEuU0cDQbORWX+kYCeo0kV1lbxF5bt4r7SID2l9bqsxJEM0zndaxpOUT7riCyIVEuqq/Ynxg==}
 
-  '@humanfs/core@0.19.1':
-    resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
+  '@humanfs/core@0.19.2':
+    resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
 
-  '@humanfs/node@0.16.7':
-    resolution: {integrity: sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==}
+  '@humanfs/node@0.16.8':
+    resolution: {integrity: sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==}
+    engines: {node: '>=18.18.0'}
+
+  '@humanfs/types@0.15.0':
+    resolution: {integrity: sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==}
     engines: {node: '>=18.18.0'}
 
   '@humanwhocodes/module-importer@1.0.1':
@@ -4193,6 +4197,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -7346,12 +7351,17 @@ snapshots:
       '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@humanfs/core@0.19.1': {}
-
-  '@humanfs/node@0.16.7':
+  '@humanfs/core@0.19.2':
     dependencies:
-      '@humanfs/core': 0.19.1
+      '@humanfs/types': 0.15.0
+
+  '@humanfs/node@0.16.8':
+    dependencies:
+      '@humanfs/core': 0.19.2
+      '@humanfs/types': 0.15.0
       '@humanwhocodes/retry': 0.4.3
+
+  '@humanfs/types@0.15.0': {}
 
   '@humanwhocodes/module-importer@1.0.1': {}
 
@@ -10960,7 +10970,7 @@ snapshots:
       '@eslint/eslintrc': 3.3.5
       '@eslint/js': 9.39.4
       '@eslint/plugin-kit': 0.4.1
-      '@humanfs/node': 0.16.7
+      '@humanfs/node': 0.16.8
       '@humanwhocodes/module-importer': 1.0.1
       '@humanwhocodes/retry': 0.4.3
       '@types/estree': 1.0.8


### PR DESCRIPTION
Updates the transitive `@humanfs/node` resolution in `pnpm-lock.yaml` from 0.16.7 to 0.16.8 with `pnpm update -r --depth Infinity`, within the existing parent ranges. Its released dependency updates are included: `@humanfs/core` 0.19.1 → 0.19.2 and runtime `@humanfs/types` 0.15.0.

Fixes Dependabot alert [#236](https://github.com/axiomhq/axiom-js/security/dependabot/236) (`GHSA-p498-v437-472g`, recursive copy following symlinks outside the source tree). The dependency path is `eslint` → `@humanfs/node` in `pnpm-lock.yaml`.

Release notes reviewed:

- [`@humanfs/node` 0.16.8](https://github.com/humanwhocodes/humanfs/blob/main/packages/node/CHANGELOG.md): preserves symlinks in `copy()`/`copyAll()` and includes type dependencies at runtime; updates `@humanfs/core` to 0.19.2.
- [`@humanfs/core` 0.19.2](https://github.com/humanwhocodes/humanfs/blob/main/packages/core/CHANGELOG.md): includes type dependencies at runtime.

The update stays within the existing 0.x package lines and retains Node `>=18.18.0` requirements. No application source changes were required.

Validation:

- `pnpm install --frozen-lockfile`
- `node /tmp/axiom-verify-alerts.cjs /tmp/axiom-security-humanfs-node '@humanfs/node'` — alert version check passes.
- `pnpm lint` — 16 tasks pass.
- `pnpm --filter @axiomhq/js build` and `pnpm --filter @axiomhq/logging build` — pass; the JS build reports the existing `fetch-retry` external dependency warning.
- `pnpm --filter @axiomhq/nextjs test` — 5 files and 26 tests pass.

Combined validation of the 15 security PRs (#511–#525) passed: frozen pnpm install, full application/package builds, CJS builds, typechecks, lint, and all unit tests. Every resolved version was checked against all 25 open Dependabot advisory ranges; none remained vulnerable. Lockfiles were generated by pnpm throughout.

