### PR TITLE
ci: use a disposable Axiom test organization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,13 @@ permissions:
   contents: read
 
 env:
-  AXIOM_TOKEN: ${{ secrets.TESTING_DEV_API_TOKEN }}
-  AXIOM_URL: ${{ secrets.TESTING_DEV_API_URL }}
-  AXIOM_ORG_ID: ${{ secrets.TESTING_DEV_ORG_ID }}
-  NEXT_PUBLIC_AXIOM_TOKEN: ${{ secrets.TESTING_DEV_INGEST_API_TOKEN }}
-  NEXT_PUBLIC_AXIOM_URL: ${{ secrets.TESTING_DEV_API_URL }}
-  NEXT_PUBLIC_AXIOM_ORG_ID: ${{ secrets.TESTING_DEV_ORG_ID }}
+  AXIOM_TOKEN: ${{ secrets.TESTING_API_TOKEN }}
+  AXIOM_URL: ${{ vars.TESTING_API_URL }}
+  AXIOM_ORG_ID: ${{ vars.TESTING_ORG_ID }}
+  NEXT_PUBLIC_AXIOM_TOKEN: ${{ secrets.TESTING_INGEST_API_TOKEN }}
+  NEXT_PUBLIC_AXIOM_URL: ${{ vars.TESTING_API_URL }}
+  NEXT_PUBLIC_AXIOM_ORG_ID: ${{ vars.TESTING_ORG_ID }}
+  TESTING_ENVIRONMENT: ${{ vars.TESTING_ENVIRONMENT }}
   AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}
   NODEVERSION: 22.x
   PNPM_VERSION: 10.4.1
@@ -109,7 +110,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     concurrency:
-      group: integration-development
+      group: integration-${{ vars.TESTING_ENVIRONMENT || 'testing' }}
       cancel-in-progress: false
     continue-on-error: true
     strategy:
@@ -120,18 +121,33 @@ jobs:
           - 22.x
           - 24.x
     env:
-      AXIOM_TOKEN: ${{ secrets.TESTING_DEV_API_TOKEN }}
-      AXIOM_URL: ${{ secrets.TESTING_DEV_API_URL }}
-      AXIOM_ORG_ID: ${{ secrets.TESTING_DEV_ORG_ID }}
-      AXIOM_EDGE: ${{ vars.TESTING_DEV_EDGE }}
-      AXIOM_EDGE_URL: ${{ vars.TESTING_DEV_EDGE_URL }}
-      AXIOM_EDGE_DATASET_REGION: ${{ vars.TESTING_DEV_EDGE_DATASET_REGION }}
-      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.node }}-development
+      AXIOM_TOKEN: ${{ secrets.TESTING_API_TOKEN }}
+      AXIOM_URL: ${{ vars.TESTING_API_URL }}
+      AXIOM_ORG_ID: ${{ vars.TESTING_ORG_ID }}
+      AXIOM_EDGE: ${{ vars.TESTING_EDGE }}
+      AXIOM_EDGE_URL: ${{ vars.TESTING_EDGE_URL }}
+      AXIOM_EDGE_DATASET_REGION: ${{ vars.TESTING_EDGE_DATASET_REGION }}
+      AXIOM_DATASET_SUFFIX: ${{ github.run_id }}-${{ github.run_attempt }}-${{ matrix.node }}-${{ vars.TESTING_ENVIRONMENT }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - name: Skip integration tests for external PRs
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.repository
         run: echo "Skipping integration tests because this run does not have access to repository secrets."
+      - name: Validate testing configuration
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: bash
+        run: |
+          missing=()
+          for name in AXIOM_TOKEN AXIOM_URL AXIOM_ORG_ID TESTING_ENVIRONMENT; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required testing configuration: ${missing[*]}"
+            exit 1
+          fi
+          echo "Testing configuration: org=${AXIOM_ORG_ID} url=${AXIOM_URL} environment=${TESTING_ENVIRONMENT}"
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         with:
@@ -170,6 +186,19 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}} #Required
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}} #Required
           scope: ${{ secrets.VERCEL_SCOPE }}
+          env: |
+            AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}
+            AXIOM_URL=${{ vars.TESTING_API_URL }}
+            AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
+            NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}
+            NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}
+            NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
+            AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}
+          build-env: |
+            NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}
+            NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}
+            NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
+            AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}
     outputs:
       preview-url: ${{ steps.vercel-deploy.outputs.preview-url }}
     environment:
@@ -206,6 +235,20 @@ jobs:
             ${{ runner.os }}-turbo-
       - run: pnpm install --frozen-lockfile
       - run: pnpm build && pnpm build:cjs # cjs build needed to run tests
+      - name: Validate testing configuration
+        shell: bash
+        run: |
+          missing=()
+          for name in AXIOM_TOKEN NEXT_PUBLIC_AXIOM_TOKEN AXIOM_URL AXIOM_ORG_ID TESTING_ENVIRONMENT; do
+            if [[ -z "${!name:-}" ]]; then
+              missing+=("$name")
+            fi
+          done
+          if (( ${#missing[@]} > 0 )); then
+            echo "Missing required testing configuration: ${missing[*]}"
+            exit 1
+          fi
+          echo "Testing configuration: org=${AXIOM_ORG_ID} url=${AXIOM_URL} environment=${TESTING_ENVIRONMENT}"
       - env:
           TESTING_TARGET_URL: ${{ needs.deploy-e2e-apps.outputs.preview-url }}
         run: pnpm run e2e

--- a/e2e/nextjs-app/README.md
+++ b/e2e/nextjs-app/README.md
@@ -1,13 +1,45 @@
-# Axiom integration tests for JS SKD
+# Axiom E2E app for JS SDK
 
 ## Quickstart
 
-Run the tests using `npm run integration`
+Run the tests using `pnpm e2e` from the repository root after building the
+packages and deploying this app.
 
-- configuration:
+The test runner and the deployed app must use the same
+`AXIOM_DATASET_SUFFIX`. The suffix defaults to `local`; CI supplies a run
+specific suffix to both the test runner and the preview deployment.
 
-define a dataset suffix variable, defaults to 'local', could be set to a pipeline id or commit hash.
+## Vercel configuration
 
-```shell
-export AXIOM_DATASET_SUFFIX="local"
-```
+The CI workflow passes server variables to the Vercel preview deployment at
+runtime, and passes the public variables and dataset suffix at build time. It
+also supplies the public variables and suffix at runtime where the app needs
+them. It does not mutate the Vercel project settings. Local or manually
+triggered deployments must provide the same values, including the same
+run-specific `AXIOM_DATASET_SUFFIX` as the test runner. The full API token is
+kept server-side and is never passed as a build-time variable:
+
+| Vercel variable | Type | Used by |
+| --- | --- | --- |
+| `AXIOM_TOKEN` | Secret | Server-side lambda and edge routes |
+| `AXIOM_URL` | Variable | Server-side lambda and edge routes |
+| `AXIOM_ORG_ID` | Variable | Server-side lambda and edge routes |
+| `NEXT_PUBLIC_AXIOM_TOKEN` | Secret | Browser and React Server Components |
+| `NEXT_PUBLIC_AXIOM_URL` | Variable | Browser and React Server Components |
+| `NEXT_PUBLIC_AXIOM_ORG_ID` | Variable | Browser and React Server Components |
+| `AXIOM_DATASET_SUFFIX` | Variable | Dataset name used by the deployed app |
+
+The `NEXT_PUBLIC_AXIOM_TOKEN` must be ingest-only because Next.js includes it
+in browser assets.
+
+Use the claimed Agent Org `axiom-js-ci-hvdu` and `https://api.axiom.co` for
+the shared CI configuration. If an Agent Org was initially created as
+temporary, claim it before using it for E2E so it does not expire after
+24 hours. Repository managers can inspect the GitHub variables and replace
+the secrets, but GitHub does not reveal saved secret values.
+
+## Access and replacement
+
+Treat these test organizations as disposable. Prefer provisioning a new Agent
+Org and updating the GitHub testing configuration over recovering access to
+an existing org. If you need access to the current org, contact `cje`.

--- a/e2e/nextjs-app/test/ingest.spec.ts
+++ b/e2e/nextjs-app/test/ingest.spec.ts
@@ -1,8 +1,42 @@
-import { Axiom } from '@axiomhq/js';
+import { Axiom, datasets } from '@axiomhq/js';
 import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+
+const datasetDeletionTimeoutMs = 30_000;
+const datasetDeletionPollIntervalMs = 250;
 
 function isNotFoundError(error: unknown) {
   return error instanceof Error && /not found/i.test(error.message);
+}
+
+async function cleanupDatasetIfExists(client: datasets.Service, datasetName: string) {
+  try {
+    await client.delete(datasetName);
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return;
+    }
+
+    throw error;
+  }
+
+  const deadline = Date.now() + datasetDeletionTimeoutMs;
+  while (true) {
+    try {
+      await client.get(datasetName);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return;
+      }
+
+      throw error;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for dataset ${datasetName} to be deleted`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, datasetDeletionPollIntervalMs));
+  }
 }
 
 describe('Ingestion & query on different runtime', () => {
@@ -12,28 +46,19 @@ describe('Ingestion & query on different runtime', () => {
   const datasetName = `axiom-js-e2e-test-${process.env.AXIOM_DATASET_SUFFIX || 'local'}`;
 
   beforeAll(async () => {
-    try {
-      await axiom.datasets.delete(datasetName);
-    } catch (error) {
-      if (!isNotFoundError(error)) throw error;
-    }
+    await cleanupDatasetIfExists(axiom.datasets, datasetName);
 
     const ds = await axiom.datasets.create({
       name: datasetName,
       description: 'This is a test dataset for datasets integration tests.',
     });
     console.log(`creating datasets for testing: ${ds.name} (${ds.id})`);
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    try {
-      const resp = await axiom.datasets.delete(datasetName);
-      expect(resp.status).toEqual(204);
-      console.log(`deleted testing dataset: ${datasetName}`);
-    } catch (error) {
-      if (!isNotFoundError(error)) throw error;
-    }
-  });
+    await cleanupDatasetIfExists(axiom.datasets, datasetName);
+    console.log(`deleted testing dataset: ${datasetName}`);
+  }, 60_000);
 
   it('ingest on a lambda function should succeed', async () => {
     const startTime = new Date(Date.now()).toISOString();

--- a/integration/README.md
+++ b/integration/README.md
@@ -1,13 +1,42 @@
-# Axiom integration tests for JS SKD
+# Axiom integration tests for JS SDK
 
 ## Quickstart
 
-Run the tests using `npm run integration`
+Run the tests using `pnpm integration`.
 
-- configuration:
-
-define a dataset suffix variable, defaults to 'local', could be set to a pipeline id or commit hash.
+The tests create datasets whose names include `AXIOM_DATASET_SUFFIX`. The
+suffix defaults to `local`; set it to a pipeline ID or commit hash when
+running against a shared organization:
 
 ```shell
 export AXIOM_DATASET_SUFFIX="local"
+pnpm integration
 ```
+
+## CI configuration
+
+The CI workflow uses the claimed Agent Org `axiom-js-ci-hvdu` at
+`https://api.axiom.co`. Configure the repository's testing environment with
+these settings:
+
+| GitHub setting | Type | Runtime variable | Purpose |
+| --- | --- | --- | --- |
+| `TESTING_API_TOKEN` | Secret | `AXIOM_TOKEN` | API token for the integration tests |
+| `TESTING_INGEST_API_TOKEN` | Secret | `NEXT_PUBLIC_AXIOM_TOKEN` | Ingest token used by the E2E app |
+| `TESTING_API_URL` | Variable | `AXIOM_URL`, `NEXT_PUBLIC_AXIOM_URL` | API endpoint (`https://api.axiom.co`) |
+| `TESTING_ORG_ID` | Variable | `AXIOM_ORG_ID`, `NEXT_PUBLIC_AXIOM_ORG_ID` | Agent Org (`axiom-js-ci-hvdu`) |
+| `TESTING_ENVIRONMENT` | Variable | `TESTING_ENVIRONMENT` | Environment namespace included in CI dataset names |
+| `TESTING_EDGE` | Variable, optional | `AXIOM_EDGE` | Edge deployment selector |
+| `TESTING_EDGE_URL` | Variable | `AXIOM_EDGE_URL` | Edge ingestion endpoint (`https://us-east-1.aws.edge.axiom.co`) |
+| `TESTING_EDGE_DATASET_REGION` | Variable | `AXIOM_EDGE_DATASET_REGION` | Dataset edge region (`cloud.us-east-1.aws`) |
+
+If an Agent Org was initially created as temporary, claim it and make it
+permanent before using it for CI. Repository managers can inspect the GitHub
+variables and replace the secrets, but GitHub does not reveal saved secret
+values.
+
+## Access and replacement
+
+Treat these test organizations as disposable. Prefer provisioning a new Agent
+Org and updating the GitHub testing configuration over recovering access to
+an existing org. If you need access to the current org, contact `cje`.

--- a/integration/src/annotations.spec.ts
+++ b/integration/src/annotations.spec.ts
@@ -23,12 +23,11 @@ describe('AnnotationsService', () => {
       name: datasetName,
       description: 'This is a test dataset to be used for annotations testing',
     });
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    const resp = await cleanupDatasetIfExists(datasetsClient, datasetName);
-    if (resp) expect(resp.status).toEqual(204);
-  });
+    await cleanupDatasetIfExists(datasetsClient, datasetName);
+  }, 60_000);
 
   describe('create', () => {
     it('creates annotations successfully', async () => {

--- a/integration/src/client.spec.ts
+++ b/integration/src/client.spec.ts
@@ -18,12 +18,11 @@ describe('Axiom', () => {
       name: datasetName,
       description: 'This is a test dataset for datasets integration tests.',
     });
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    const resp = await cleanupDatasetIfExists(axiom.datasets, datasetName);
-    if (resp) expect(resp.status).toEqual(204);
-  });
+    await cleanupDatasetIfExists(axiom.datasets, datasetName);
+  }, 60_000);
 
   describe('ingest', () => {
     it('works with a JSON payload', async () => {

--- a/integration/src/datasets.spec.ts
+++ b/integration/src/datasets.spec.ts
@@ -17,12 +17,11 @@ describe('DatasetsService', () => {
       name: datasetName,
       description: 'This is a test dataset for datasets integration tests.',
     });
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    const resp = await cleanupDatasetIfExists(client, datasetName);
-    if (resp) expect(resp.status).toEqual(204);
-  });
+    await cleanupDatasetIfExists(client, datasetName);
+  }, 60_000);
 
   describe('update', () => {
     it('should update the dataset', async () => {

--- a/integration/src/edge.spec.ts
+++ b/integration/src/edge.spec.ts
@@ -46,13 +46,12 @@ describe.skipIf(!hasEdgeConfig)('Edge Ingestion', () => {
       createRequest.edgeDeployment = edgeDatasetRegion;
     }
     await createTestDataset(axiom.datasets, createRequest);
-  });
+  }, 60_000);
 
   afterAll(async () => {
     // Delete dataset (API call goes to main URL, not edge)
-    const resp = await cleanupDatasetIfExists(axiom.datasets, datasetName);
-    if (resp) expect(resp.status).toEqual(204);
-  });
+    await cleanupDatasetIfExists(axiom.datasets, datasetName);
+  }, 60_000);
 
   describe('ingest via edge', () => {
     it('works with single event', async () => {

--- a/integration/src/monitors.spec.ts
+++ b/integration/src/monitors.spec.ts
@@ -25,12 +25,11 @@ describe('MonitorsService', () => {
       name: datasetName,
       description: 'This is a test dataset to be used for annotations testing',
     });
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    const resp = await cleanupDatasetIfExists(datasetsClient, datasetName);
-    if (resp) expect(resp.status).toEqual(204);
-  });
+    await cleanupDatasetIfExists(datasetsClient, datasetName);
+  }, 60_000);
 
   it('Create', async () => {
     const request: monitors.CreateRequest = {

--- a/integration/src/testHelpers.ts
+++ b/integration/src/testHelpers.ts
@@ -1,7 +1,32 @@
 import { datasets } from '@axiomhq/js';
 
+const datasetDeletionTimeoutMs = 30_000;
+const datasetDeletionPollIntervalMs = 250;
+
 export function isNotFoundError(error: unknown) {
   return error instanceof Error && /not found/i.test(error.message);
+}
+
+async function waitForDatasetDeletion(client: datasets.Service, datasetName: string) {
+  const deadline = Date.now() + datasetDeletionTimeoutMs;
+
+  while (true) {
+    try {
+      await client.get(datasetName);
+    } catch (error) {
+      if (isNotFoundError(error)) {
+        return;
+      }
+
+      throw error;
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(`Timed out waiting for dataset ${datasetName} to be deleted`);
+    }
+
+    await new Promise(resolve => setTimeout(resolve, datasetDeletionPollIntervalMs));
+  }
 }
 
 /**
@@ -10,14 +35,16 @@ export function isNotFoundError(error: unknown) {
  */
 export async function cleanupDatasetIfExists(client: datasets.Service, datasetName: string) {
   try {
-    return await client.delete(datasetName);
+    await client.delete(datasetName);
   } catch (error) {
     if (isNotFoundError(error)) {
-      return undefined;
+      return;
     }
 
     throw error;
   }
+
+  await waitForDatasetDeletion(client, datasetName);
 }
 
 /**

--- a/integration/src/winston.spec.ts
+++ b/integration/src/winston.spec.ts
@@ -33,12 +33,11 @@ describe('WinstonTransport', () => {
       name: datasetName,
       description: 'This is a test dataset for datasets integration tests.',
     });
-  });
+  }, 60_000);
 
   afterAll(async () => {
-    const resp = await cleanupDatasetIfExists(axiom.datasets, datasetName);
-    if (resp) expect(resp.status).toEqual(204);
-  });
+    await cleanupDatasetIfExists(axiom.datasets, datasetName);
+  }, 60_000);
 
   it('sends logs to Axiom', async () => {
     logger.log({


### PR DESCRIPTION
CI was failing during dataset setup because the shared DEV credentials returned 403. This switches integration and E2E tests to the claimed, disposable `axiom-js-ci-hvdu` organization. The org ID, API URL, environment, and edge configuration are readable repository variables; API and ingest-only tokens remain repository secrets. Preview deployments receive the same runtime/build configuration as the E2E runner.

Production dataset deletion returns a successful 200 job response rather than the 204 expected by the tests. Cleanup now waits until the dataset is absent, and setup/teardown hooks allow time for asynchronous deletion.

The setup docs say to contact `cje` for access to the current org, but prefer provisioning a replacement because these organizations are disposable.

Validation: all 28 live integration tests and all six suites passed against the claimed org; integration lint/build, E2E TypeScript checking, and workflow YAML validation passed. The ingest-only token was verified to ingest successfully and receive 403 on dataset deletion. Deployed E2E validation is pending CI. The new repository variables and secrets are already configured; this PR activates them in CI.
