### PR TITLE
ci: test Node.js 24 and 26

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,19 +186,23 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}} #Required
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}} #Required
           scope: ${{ secrets.VERCEL_SCOPE }}
-          env: |
-            AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}
-            AXIOM_URL=${{ vars.TESTING_API_URL }}
-            AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
-            NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}
-            NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}
-            NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
-            AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}
-          build-env: |
-            NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}
-            NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}
-            NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
-            AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}
+          # The action only forwards env/build-env inputs in experimental API mode.
+          # CLI flags also override stale project credentials during the Next.js build.
+          vercel-args: >-
+            --env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
+            --env AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
+            --build-env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
+            --build-env AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --build-env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --build-env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --build-env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --build-env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --build-env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
     outputs:
       preview-url: ${{ steps.vercel-deploy.outputs.preview-url }}
     environment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,9 +34,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.x
-          - 22.x
           - 24.x
+          - 26.x
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -89,9 +88,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.x
-          - 22.x
           - 24.x
+          - 26.x
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6
@@ -117,9 +115,8 @@ jobs:
       fail-fast: true
       matrix:
         node:
-          - 20.x
-          - 22.x
           - 24.x
+          - 26.x
     env:
       AXIOM_TOKEN: ${{ secrets.TESTING_API_TOKEN }}
       AXIOM_URL: ${{ vars.TESTING_API_URL }}
@@ -218,7 +215,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - 20.x
+          - 24.x
+          - 26.x
       max-parallel: 1
       fail-fast: true
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,20 +189,20 @@ jobs:
           # The action only forwards env/build-env inputs in experimental API mode.
           # CLI flags also override stale project credentials during the Next.js build.
           vercel-args: >-
-            --env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
-            --env AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
-            --env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
-            --build-env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
-            --build-env AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --build-env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --build-env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
-            --build-env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --build-env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --build-env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
+            --env "AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}"
+            --env "AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --env "AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --env "NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --env "NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --env "NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --env "AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}"
+            --build-env "AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}"
+            --build-env "AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --build-env "AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --build-env "NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --build-env "NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --build-env "NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --build-env "AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}"
     outputs:
       preview-url: ${{ steps.vercel-deploy.outputs.preview-url }}
     environment:


### PR DESCRIPTION
Run the build, Winston example, integration, and E2E job matrices on Node.js 24.x and 26.x.

The branch includes the E2E configuration fix already merged in #531. Compared with current main, the resulting change is limited to the four Node matrices. Builds, unit tests, integration tests, and deployed Lambda/Edge E2E tests are being verified on both versions.
