### PR TITLE
ci: pass test credentials through Vercel CLI flags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,19 +186,23 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID}} #Required
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID}} #Required
           scope: ${{ secrets.VERCEL_SCOPE }}
-          env: |
-            AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}
-            AXIOM_URL=${{ vars.TESTING_API_URL }}
-            AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
-            NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}
-            NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}
-            NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
-            AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}
-          build-env: |
-            NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}
-            NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}
-            NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}
-            AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}
+          # The action only forwards env/build-env inputs in experimental API mode.
+          # CLI flags also override stale project credentials during the Next.js build.
+          vercel-args: >-
+            --env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
+            --env AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
+            --build-env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
+            --build-env AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --build-env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --build-env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --build-env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
+            --build-env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
+            --build-env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
     outputs:
       preview-url: ${{ steps.vercel-deploy.outputs.preview-url }}
     environment:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,20 +189,20 @@ jobs:
           # The action only forwards env/build-env inputs in experimental API mode.
           # CLI flags also override stale project credentials during the Next.js build.
           vercel-args: >-
-            --env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
-            --env AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
-            --env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
-            --build-env AXIOM_TOKEN="${{ secrets.TESTING_API_TOKEN }}"
-            --build-env AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --build-env AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --build-env NEXT_PUBLIC_AXIOM_TOKEN="${{ secrets.TESTING_INGEST_API_TOKEN }}"
-            --build-env NEXT_PUBLIC_AXIOM_URL="${{ vars.TESTING_API_URL }}"
-            --build-env NEXT_PUBLIC_AXIOM_ORG_ID="${{ vars.TESTING_ORG_ID }}"
-            --build-env AXIOM_DATASET_SUFFIX="${{ env.AXIOM_DATASET_SUFFIX }}"
+            --env "AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}"
+            --env "AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --env "AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --env "NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --env "NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --env "NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --env "AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}"
+            --build-env "AXIOM_TOKEN=${{ secrets.TESTING_API_TOKEN }}"
+            --build-env "AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --build-env "AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --build-env "NEXT_PUBLIC_AXIOM_TOKEN=${{ secrets.TESTING_INGEST_API_TOKEN }}"
+            --build-env "NEXT_PUBLIC_AXIOM_URL=${{ vars.TESTING_API_URL }}"
+            --build-env "NEXT_PUBLIC_AXIOM_ORG_ID=${{ vars.TESTING_ORG_ID }}"
+            --build-env "AXIOM_DATASET_SUFFIX=${{ env.AXIOM_DATASET_SUFFIX }}"
     outputs:
       preview-url: ${{ steps.vercel-deploy.outputs.preview-url }}
     environment:


### PR DESCRIPTION
The E2E previews still use the old Vercel project credentials because the pinned action ignores its `env` and `build-env` inputs in its default CLI mode. Dataset setup succeeds against the new org, but both deployed ingestion routes return HTTP 500.

Pass the repository test configuration through the supported `--env` and `--build-env` CLI flags. Set the server credentials at build time too so the Next.js Edge bundle receives the same org as the test runner. The browser token remains the separate ingest-only token.

Quote each complete `KEY=value` argument: the action’s parser preserves quotes embedded after `=`, which otherwise produces invalid URLs and tokens.

Validated the workflow YAML and all 14 environment assignments with the pinned action’s argument parser. Deployed E2E validation is running in CI.
